### PR TITLE
Use GitHub as the repo for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
CI was failing due to issues with GitLab when trying to install flake8.
See issue here: https://github.com/AICoE/aicoe-ci/issues/53