### PR TITLE
Remove simple history records from DataUseOntologyModel

### DIFF
--- a/primed/primed_anvil/models.py
+++ b/primed/primed_anvil/models.py
@@ -110,7 +110,6 @@ class DataUseOntologyModel(models.Model):
         null=True,
         help_text="The disease restriction if required by data_use_permission.",
     )
-    history = HistoricalRecords()
 
     class Meta:
         abstract = True


### PR DESCRIPTION
This is an abstract model, so it having the historical records does nothing. Remove the history field so a warning is not produced.