### PR TITLE
Only show alert on snapshots that are not the most recent

### DIFF
--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -2409,6 +2409,29 @@ class dbGaPDataAccessSnapshotDetailTest(TestCase):
         table = response.context_data["summary_table"]
         self.assertEqual(len(table.rows), 0)
 
+    def test_no_alert_for_most_recent_snapshot(self):
+        """No alert is shown when this is the most recent snapshot for an application."""
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(self.application.dbgap_project_id, self.snapshot.pk)
+        )
+        self.assertNotContains(
+            response, "not the most recent snapshot", status_code=200
+        )
+
+    def test_alert_when_not_most_recent_snapshot(self):
+        """An alert is shown when this is not the most recent snapshot for an application."""
+        old_snapshot = factories.dbGaPDataAccessSnapshotFactory.create(
+            dbgap_application=self.application,
+            created=timezone.now() - timedelta(weeks=5),
+            is_most_recent=False,
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(self.application.dbgap_project_id, old_snapshot.pk)
+        )
+        self.assertContains(response, "not the most recent snapshot", status_code=200)
+
 
 class dbGaPDataAccessSnapshotAuditTest(TestCase):
     """Tests for the dbGaPDataAccessRequestAudit view."""
@@ -2707,3 +2730,26 @@ class dbGaPDataAccessSnapshotAuditTest(TestCase):
             audit.dbGaPDataAccessSnapshotAudit.ERROR_HAS_ACCESS,
         )
         self.assertIsNotNone(table.rows[0].get_cell_value("action"))
+
+    def test_no_alert_for_most_recent_snapshot(self):
+        """No alert is shown when this is the most recent snapshot for an application."""
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(self.application.dbgap_project_id, self.snapshot.pk)
+        )
+        self.assertNotContains(
+            response, "not the most recent snapshot", status_code=200
+        )
+
+    def test_alert_when_not_most_recent_snapshot(self):
+        """An alert is shown when this is not the most recent snapshot for an application."""
+        old_snapshot = factories.dbGaPDataAccessSnapshotFactory.create(
+            dbgap_application=self.application,
+            created=timezone.now() - timedelta(weeks=5),
+            is_most_recent=False,
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(self.application.dbgap_project_id, old_snapshot.pk)
+        )
+        self.assertContains(response, "not the most recent snapshot", status_code=200)

--- a/primed/templates/dbgap/dbgapdataaccesssnapshot_detail.html
+++ b/primed/templates/dbgap/dbgapdataaccesssnapshot_detail.html
@@ -4,9 +4,11 @@
 {% block title %}DAR snapshot{% endblock %}
 
 {% block pills %}
-<div class="alert alert-danger" role="alert">
-  This is not the most recent snapshot for this dbGaP application!
-</div>
+  {% if not object.is_most_recent %}
+    <div class="alert alert-danger" role="alert">
+      This is not the most recent snapshot for this dbGaP application!
+    </div>
+  {% endif %}
 {% endblock pills %}
 
 {% block panel %}


### PR DESCRIPTION
Only show an alert on the dbGaPDataAccessSnapshotDetail page when it is not the most recent snapshot available.

Fixes #69 