### PR TITLE
Filter to approved DARs when setting original_version and participant…

### DIFF
--- a/primed/dbgap/models.py
+++ b/primed/dbgap/models.py
@@ -301,9 +301,13 @@ class dbGaPDataAccessSnapshot(TimeStampedModel, models.Model):
                 # Try looking up the original version and participant set from a previous DAR.
                 try:
                     # This assumes that a DAR/dbgap_dar_id remains the same for the same phs and consent code.
-                    previous_dar = dbGaPDataAccessRequest.objects.filter(
-                        dbgap_dar_id=request_json["DAR"]
-                    ).latest("created")
+                    previous_dar = (
+                        dbGaPDataAccessRequest.objects.approved()
+                        .filter(
+                            dbgap_dar_id=request_json["DAR"],
+                        )
+                        .latest("created")
+                    )
                     # Make sure that excepted values match.
                     # Is ValueError the best error to raise?
                     if previous_dar.dbgap_phs != phs:

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -1758,7 +1758,7 @@ class dbGaPDataAccessSnapshotCreateTest(TestCase):
             dbgap_consent_abbreviation=self.valid_json[0]["studies"][0]["requests"][0][
                 "consent_abbrev"
             ],
-            dbgap_current_status="new",
+            dbgap_current_status="approved",
             original_version=3,
             original_participant_set=2,
         )
@@ -1800,7 +1800,7 @@ class dbGaPDataAccessSnapshotCreateTest(TestCase):
             dbgap_consent_abbreviation=self.valid_json[0]["studies"][0]["requests"][0][
                 "consent_abbrev"
             ],
-            dbgap_current_status="new",
+            dbgap_current_status="approved",
             original_version=3,
             original_participant_set=2,
         )


### PR DESCRIPTION
… set

Previously, the code looked up version and participant set from any previous DAR with the same dbgap_dar_id. In the situation where version and participant set got set for a "new" DAR and the study updated to a new version before the DAR got approved, we would pull the version and participant set from the "new" DAR. It would therefore be incorrect. Modify the code to filter to DARs that have the same dbgap_dar_id *and* are approved, and if there are none, then query dbGaP for the current version.