### PR TITLE
Redirect to profile after login

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -308,6 +308,7 @@ LOGIN_REQUIRED_IGNORE_VIEW_NAMES = [
     "socialaccount_signup",
     "admin:index",
     "admin:login",
+    "home",
 ]
 
 # django-dbbackup


### PR DESCRIPTION
Instead of redirecting to home, redirect to profile after login by default.

Previously, the home page was set to LoginRequired via the login-required middleware. This redirects the user to a login page and sets the "next" url parameter to the page they were trying to access. Because the next parameter is set, it skips the LOGIN_REDIRECT_URL setting which is set to the user's profile page.

Closes #76