### PR TITLE
Add number of groups to the custom AccountList

### DIFF
--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -32,6 +32,12 @@ class AccountTable(tables.Table):
     email = tables.Column(linkify=True)
     user__name = tables.Column(linkify=lambda record: record.user.get_absolute_url())
     is_service_account = tables.BooleanColumn(verbose_name="Service account?")
+    number_groups = tables.Column(
+        verbose_name="Number of groups",
+        empty_values=(),
+        orderable=False,
+        accessor="groupaccountmembership_set__count",
+    )
 
     class Meta:
         model = Account

--- a/primed/primed_anvil/tests/test_tables.py
+++ b/primed/primed_anvil/tests/test_tables.py
@@ -1,5 +1,8 @@
 from anvil_consortium_manager.models import Account
-from anvil_consortium_manager.tests.factories import AccountFactory
+from anvil_consortium_manager.tests.factories import (
+    AccountFactory,
+    GroupAccountMembershipFactory,
+)
 from django.test import TestCase
 
 from primed.users.tests.factories import UserFactory
@@ -81,6 +84,17 @@ class AccountTableTest(TestCase):
         self.model_factory.create(user=None)
         table = self.table_class(self.model.objects.all())
         self.assertEqual(len(table.rows), 1)
+
+    def test_number_groups(self):
+        self.model_factory.create()
+        account_1 = self.model_factory.create()
+        account_2 = self.model_factory.create()
+        GroupAccountMembershipFactory.create_batch(1, account=account_1)
+        GroupAccountMembershipFactory.create_batch(2, account=account_2)
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.rows[0].get_cell("number_groups"), 0)
+        self.assertEqual(table.rows[1].get_cell("number_groups"), 1)
+        self.assertEqual(table.rows[2].get_cell("number_groups"), 2)
 
 
 class AvailableDataTableTest(TestCase):


### PR DESCRIPTION
Display the number of groups that an account is part of in the custom django-tables2 AccountTable.

Closes #118