### PR TITLE
Modify detail templates to match new ACM style

### DIFF
--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -1252,44 +1252,27 @@ class dbGaPApplicationDetailTest(TestCase):
             len(response.context_data["data_access_snapshot_table"].rows), 0
         )
 
-    def test_context_has_snapshot_no_snapshot(self):
-        """has_snapshot is False in context when there no dbGaPDataAccessSnapshot for this application."""
+    def test_context_latest_snapshot_no_snapshot(self):
+        """latest_snapshot is None in context when there are no dbGaPDataAccessSnapshots for this application."""
         request = self.factory.get(self.get_url(self.obj.dbgap_project_id))
         request.user = self.user
         response = self.get_view()(request, dbgap_project_id=self.obj.dbgap_project_id)
-        self.assertIn("has_snapshot", response.context_data)
-        self.assertFalse(response.context_data["has_snapshot"])
+        self.assertIn("latest_snapshot", response.context_data)
+        self.assertIsNone(response.context_data["latest_snapshot"])
 
-    def test_context_has_snapshot_one_snapshot(self):
-        """has_snapshot is True in context when there is a dbGaPDataAccessSnapshot for this application."""
-        factories.dbGaPDataAccessSnapshotFactory.create(dbgap_application=self.obj)
-        request = self.factory.get(self.get_url(self.obj.dbgap_project_id))
-        request.user = self.user
-        response = self.get_view()(request, dbgap_project_id=self.obj.dbgap_project_id)
-        self.assertIn("has_snapshot", response.context_data)
-        self.assertTrue(response.context_data["has_snapshot"])
-
-    def test_context_last_update_no_snapshot(self):
-        """last_update is None in context when there are no dbGaPDataAccessSnapshots for this application."""
-        request = self.factory.get(self.get_url(self.obj.dbgap_project_id))
-        request.user = self.user
-        response = self.get_view()(request, dbgap_project_id=self.obj.dbgap_project_id)
-        self.assertIn("last_update", response.context_data)
-        self.assertIsNone(response.context_data["last_update"])
-
-    def test_context_last_update_one_snapshot(self):
-        """last_update is correct in context when there is one dbGaPDataAccessSnapshot for this application."""
+    def test_context_latest_snapshot_one_snapshot(self):
+        """latest_snapshot is correct in context when there is one dbGaPDataAccessSnapshot for this application."""
         dbgap_snapshot = factories.dbGaPDataAccessSnapshotFactory.create(
             dbgap_application=self.obj
         )
         request = self.factory.get(self.get_url(self.obj.dbgap_project_id))
         request.user = self.user
         response = self.get_view()(request, dbgap_project_id=self.obj.dbgap_project_id)
-        self.assertIn("last_update", response.context_data)
-        self.assertEqual(response.context_data["last_update"], dbgap_snapshot.created)
+        self.assertIn("latest_snapshot", response.context_data)
+        self.assertEqual(response.context_data["latest_snapshot"], dbgap_snapshot)
 
-    def test_context_last_update_two_snapshots(self):
-        """last_update is correct in context when there are two dbGaPDataAccessSnapshots for this application."""
+    def test_context_latest_snapshot_two_snapshots(self):
+        """latest_snapshot is correct in context when there are two dbGaPDataAccessSnapshots for this application."""
         factories.dbGaPDataAccessSnapshotFactory.create(
             dbgap_application=self.obj, created=timezone.now() - timedelta(weeks=4)
         )
@@ -1299,8 +1282,8 @@ class dbGaPApplicationDetailTest(TestCase):
         request = self.factory.get(self.get_url(self.obj.dbgap_project_id))
         request.user = self.user
         response = self.get_view()(request, dbgap_project_id=self.obj.dbgap_project_id)
-        self.assertIn("last_update", response.context_data)
-        self.assertEqual(response.context_data["last_update"], dbgap_snapshot.created)
+        self.assertIn("latest_snapshot", response.context_data)
+        self.assertEqual(response.context_data["latest_snapshot"], dbgap_snapshot)
 
     def test_table_default_ordering(self):
         """Most recent dbGaPDataAccessSnapshots appear first."""

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -151,11 +151,9 @@ class dbGaPApplicationDetail(
         """
         context = super().get_context_data(*args, **kwargs)
         if self.latest_snapshot:
-            context["has_snapshot"] = True
-            context["last_update"] = self.latest_snapshot.created
+            context["latest_snapshot"] = self.latest_snapshot
         else:
-            context["has_snapshot"] = False
-            context["last_update"] = None
+            context["latest_snapshot"] = None
         return context
 
 

--- a/primed/templates/dbgap/dbgapapplication_detail.html
+++ b/primed/templates/dbgap/dbgapapplication_detail.html
@@ -4,18 +4,27 @@
 {% block title %}dbGaP application {{ object }}{% endblock %}
 
 {% block panel %}
-  <ul>
-    <li>Principal Investigator: {{ object.principal_investigator }}</li>
-    <li>dbGaP Project ID: {{ object.dbgap_project_id }}</li>
-    <li>AnVIL Group: <a href="{{ object.anvil_group.get_absolute_url }}">{{ object.anvil_group }}</a></li>
-    <li>Date created: {{ object.created }}</li>
-    <li>Date modified: {{ object.modified }}</li>
-    <li>Last DAR update: {{ last_update|default:"Never" }}</li>
-  </ul>
+<dl class="row">
+  <hr>
+  <dt class="col-sm-2">dbGaP PI</dt> <dd class="col-sm-9">{{ object.principal_investigator }}</dd>
+  <dt class="col-sm-2">dbGaP Project ID</dt> <dd class="col-sm-9">{{ object.dbgap_project_id }}</dd>
+  <dt class="col-sm-2">AnVIL access Group</dt> <dd class="col-sm-9">
+    <a href="{{ object.anvil_group.get_absolute_url }}">{{ object.anvil_group }}</a>
+  </dd>
+  <dt class="col-sm-2">Date created</dt> <dd class="col-sm-9">{{ object.created }}</dd>
+  <dt class="col-sm-2">Date modified</dt> <dd class="col-sm-9">{{ object.modified }}</dd>
+  <dt class="col-sm-2">Last DAR update</dt> <dd class="col-sm-9">
+    {% if latest_snapshot %}
+      <a href="{{ latest_snapshot.get_absolute_url }}">{{ last_snapshot.created }}</a>
+    {% else %}
+      	—
+    {% endif %}
+  </dd>
+</dl>
 {% endblock panel %}
 
 {% block after_panel %}
-  {% if has_snapshot %}
+  {% if latest_snapshot %}
     <h3>Data access snapshots</h3>
     {% render_table data_access_snapshot_table %}
   {% endif %}

--- a/primed/templates/dbgap/dbgapdataaccesssnapshot_detail.html
+++ b/primed/templates/dbgap/dbgapdataaccesssnapshot_detail.html
@@ -12,11 +12,13 @@
 {% endblock pills %}
 
 {% block panel %}
-  <ul>
-    <li>dbGaP application: <a href="{{ object.dbgap_application.get_absolute_url }}">{{ object.dbgap_application }}</a></li>
-    <li>Date created: {{ object.created }}</li>
-    <li>Date modified: {{ object.modified }}</li>
-  </ul>
+  <dl class="row">
+    <dt class="col-sm-2">dbGaP application</dt> <dd class="col-sm-10">
+      <a href="{{ object.dbgap_application.get_absolute_url }}">{{ object.dbgap_application }}</a>
+    </dd>
+    <dt class="col-sm-2">Date created</dt> <dd class="col-sm-10">{{ object.created }}</dd>
+    <dt class="col-sm-2">Date modified</dt> <dd class="col-sm-10">{{ object.modified }}</dd>
+  </dl>
 {% endblock panel %}
 
 {% block after_panel %}

--- a/primed/templates/dbgap/dbgapstudyaccession_detail.html
+++ b/primed/templates/dbgap/dbgapstudyaccession_detail.html
@@ -4,17 +4,17 @@
 {% block title %}dbGaP study accession: {{ object }}{% endblock title %}
 
 {% block panel %}
-  <ul>
-    <li>
-      Studies:
-      {% for study in object.studies.all %}
-      <a href="{{ study.get_absolute_url }}">{{ study }}</a>{% if not forloop.last %} , {% endif %}
-      {% endfor %}
-    </li>
-    <li>dbGaP accession: {{ object }}</li>
-    <li>Date created: {{ object.created }}</li>
-    <li>Date modified: {{ object.modified }}</li>
-  </ul>
+<dl class="row">
+  <dt class="col-sm-2">Studies</dt> <dd class="col-sm-10">
+    {% for study in object.studies.all %}
+    <a href="{{ study.get_absolute_url }}">{{ study }}</a>{% if not forloop.last %} , {% endif %}
+    {% endfor %}
+  </dd>
+  <dt class="col-sm-2">dbGaP accession</dt> <dd class="col-sm-10">{{ object }}</dd>
+  <dt class="col-sm-2">Date created</dt> <dd class="col-sm-10">{{ object.created }}</dd>
+  <dt class="col-sm-2">Date modified</dt> <dd class="col-sm-10">{{ object.modified }}</dd>
+</dl>
+
 {% endblock panel %}
 
 {% block after_panel %}

--- a/primed/templates/duo/datausemodifier_detail.html
+++ b/primed/templates/duo/datausemodifier_detail.html
@@ -11,13 +11,13 @@
 {% endblock after_title %}
 
 {% block panel %}
-  <ul>
-    <li>Identifier: {{ object.identifier }}</li>
-    <li>Abbreviation: {{ object.abbreviation }}</li>
-    <li>Term: {{ object.term }}</li>
-    <li>Definition: {{ object.definition }}</li>
-    <li>Comment: {{ object.comment }}</li>
-  </ul>
+  <dl class="row">
+    <dt class="col-sm-2">Identifier</dt> <dd class="col-sm-10">{{ object.identifier }}</dd>
+    <dt class="col-sm-2">Term</dt> <dd class="col-sm-10">{{ object.term }}</dd>
+    <dt class="col-sm-2">Abbreviation</dt> <dd class="col-sm-10">{{ object.abbreviation }}</dd>
+    <dt class="col-sm-2">Definition</dt> <dd class="col-sm-10">{{ object.definition }}</dd>
+    <dt class="col-sm-2">Comment</dt> <dd class="col-sm-10">{{ object.comment }}</dd>
+  </dl>
 {% endblock panel %}
 
 {% block after_panel %}

--- a/primed/templates/duo/datausepermission_detail.html
+++ b/primed/templates/duo/datausepermission_detail.html
@@ -11,14 +11,14 @@
 {% endblock after_title %}
 
 {% block panel %}
-  <ul>
-    <li>Identifier: {{ object.identifier }}</li>
-    <li>Abbreviation: {{ object.abbreviation }}</li>
-    <li>Term: {{ object.term }}</li>
-    <li>Definition: {{ object.definition }}</li>
-    <li>Comment: {{ object.comment }}</li>
-    <li>Requires disease restriction? {{ object.requires_disease_restriction }}</li>
-  </ul>
+<dl class="row">
+  <dt class="col-sm-2">Identifier</dt> <dd class="col-sm-10">{{ object.identifier }}</dd>
+  <dt class="col-sm-2">Term</dt> <dd class="col-sm-10">{{ object.term }}</dd>
+  <dt class="col-sm-2">Abbreviation</dt> <dd class="col-sm-10">{{ object.abbreviation }}</dd>
+  <dt class="col-sm-2">Definition</dt> <dd class="col-sm-10">{{ object.definition }}</dd>
+  <dt class="col-sm-2">Comment</dt> <dd class="col-sm-10">{{ object.comment }}</dd>
+  <dt class="col-sm-2">Requires disease term?</dt> <dd class="col-sm-10">{{ object.requires_disease_term }}</dd>
+</dl>
 {% endblock panel %}
 
 {% block after_panel %}

--- a/primed/templates/primed_anvil/study_detail.html
+++ b/primed/templates/primed_anvil/study_detail.html
@@ -5,12 +5,12 @@
 
 
 {% block panel %}
-  <ul>
-    <li>Short name: {{ object.short_name }}</li>
-    <li>Full name: {{ object.full_name }}</li>
-    <li>Date created: {{ object.created }}</li>
-    <li>Date modified: {{ object.modified }}</li>
-  </ul>
+  <dl class="row">
+    <dt class="col-sm-2">Short name</dt> <dd class="col-sm-10">{{ object.short_name }}</dd>
+    <dt class="col-sm-2">Full name</dt> <dd class="col-sm-10">{{ object.full_name }}</dd>
+    <dt class="col-sm-2">Date created</dt> <dd class="col-sm-10">{{ object.created }}</dd>
+    <dt class="col-sm-2">Date modified</dt> <dd class="col-sm-10">{{ object.modified }}</dd>
+  </dl>
 {% endblock panel %}
 
 {% block after_panel %}

--- a/primed/templates/primed_anvil/studysite_detail.html
+++ b/primed/templates/primed_anvil/studysite_detail.html
@@ -3,15 +3,15 @@
 {% block title %}Study Site: {{ object.short_name }}{% endblock %}
 
 {% block panel %}
-  <ul>
-    <li>Full name: {{ object.full_name }}</li>
-    <li>Short name: {{ object.short_name }}</li>
-  </ul>
+  <dl class="row">
+    <dt class="col-sm-2">Full name</dt> <dd class="col-sm-10">{{ object.full_name }}</dd>
+    <dt class="col-sm-2">Short name</dt> <dd class="col-sm-10">{{ object.short_name }}</dd>
+  </dl>
 {% endblock panel %}
 
 
 {% block after_panel %}
   <h3>Study Site Users</h3>
-  {% render_table site_user_table %}
   <p class='alert alert-warning'>Study site user list only contains those site users who have created an account on this website.</p>
+  {% render_table site_user_table %}
 {% endblock after_panel %}


### PR DESCRIPTION
ACM switched from using a ul in the detail box to using a dl. Modify the detail templates in primed-specific apps to match. Also modify the dbGaPApplicationDetail view to pass the latest snapshot to the template instead of passing the last update date.