### PR TITLE
Fix merge conflict resolution for BooleanCheckColumn

### DIFF
--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -20,6 +20,9 @@ class BooleanCheckColumn(tables.BooleanColumn):
                     icon, color
                 )
             )
+        else:
+            value = ""
+        return value
 
 
 class WorkspaceSharedWithConsortiumTable(tables.Table):

--- a/primed/primed_anvil/tests/test_tables.py
+++ b/primed/primed_anvil/tests/test_tables.py
@@ -136,3 +136,12 @@ class DataSummaryTableTest(TestCase):
         table = self.table_class([])
         self.assertEqual(table.columns[3].name, "Bar")
         self.assertEqual(table.columns[4].name, "Foo")
+
+
+class BooleanCheckColumnTest(TestCase):
+    def test_render_available_data(self):
+        factories.AvailableDataFactory.create(name="Foo")
+        self.assertIn(
+            "bi-check-circle-fill", tables.BooleanCheckColumn().render(True, None, None)
+        )
+        self.assertEqual(tables.BooleanCheckColumn().render(False, None, None), "")


### PR DESCRIPTION
In the merge conflict resolution, I accidentally removed the return value from BooleanCheckColumn.render(). This caused the data summary table to display "None" for all the available data types. Add a test to verify that BooleanCheckColumn.render() is working as expected and fix the error.