### PR TITLE
Sort tables alphabetically

### DIFF
--- a/primed/cdsa/tables.py
+++ b/primed/cdsa/tables.py
@@ -49,6 +49,7 @@ class SignedAgreementTable(tables.Table):
             "date_signed",
             "number_accessors",
         )
+        order_by = ("cc_id",)
 
 
 class MemberAgreementTable(tables.Table):
@@ -80,6 +81,7 @@ class MemberAgreementTable(tables.Table):
             "signed_agreement__date_signed",
             "number_accessors",
         )
+        order_by = ("signed_agreement__cc_id",)
 
 
 class DataAffiliateAgreementTable(tables.Table):
@@ -111,6 +113,7 @@ class DataAffiliateAgreementTable(tables.Table):
             "signed_agreement__date_signed",
             "number_accessors",
         )
+        order_by = ("signed_agreement__cc_id",)
 
 
 class NonDataAffiliateAgreementTable(tables.Table):
@@ -140,6 +143,7 @@ class NonDataAffiliateAgreementTable(tables.Table):
             "signed_agreement__date_signed",
             "number_accessors",
         )
+        order_by = ("signed_agreement__cc_id",)
 
 
 class RepresentativeRecordsTable(tables.Table):
@@ -154,12 +158,12 @@ class RepresentativeRecordsTable(tables.Table):
     class Meta:
         model = models.SignedAgreement
         fields = (
-            "cc_id",
             "representative__name",
             "representative_role",
             "signing_institution",
             "signing_group",
         )
+        order_by = ("representative__name",)
 
     def render_signing_group(self, record):
         if hasattr(record, "memberagreement"):
@@ -179,13 +183,16 @@ class StudyRecordsTable(tables.Table):
     signed_agreement__representative__name = tables.Column(
         verbose_name="Representative"
     )
+    # This will only order properly if the order_by value is a column in the table.
+    study__short_name = tables.Column(verbose_name="Study")
 
     class Meta:
         model = models.DataAffiliateAgreement
         fields = (
-            "study",
+            "study__short_name",
             "signed_agreement__representative__name",
         )
+        order_by = ("study__short_name",)
 
 
 class UserAccessRecordsTable(tables.Table):
@@ -207,6 +214,7 @@ class UserAccessRecordsTable(tables.Table):
             "group__signedagreement__signing_institution",
             "group__signedagreement__representative__name",
         )
+        order_by = ("account__user__name",)
 
     def render_signing_group(self, record):
         if hasattr(record.group.signedagreement, "memberagreement"):
@@ -246,6 +254,7 @@ class CDSAWorkspaceRecordsTable(tables.Table):
             "workspace__created",
             "date_shared",
         )
+        order_by = ("workspace__name",)
 
     def render_date_shared(self, record):
         try:
@@ -282,3 +291,4 @@ class CDSAWorkspaceTable(WorkspaceSharedWithConsortiumTable, tables.Table):
             "cdsaworkspace__data_use_permission__abbreviation",
             "cdsaworkspace__data_use_modifiers",
         )
+        order_by = ("name",)

--- a/primed/cdsa/tests/test_tables.py
+++ b/primed/cdsa/tests/test_tables.py
@@ -8,6 +8,7 @@ from anvil_consortium_manager.tests.factories import (
 from django.test import TestCase
 
 from primed.primed_anvil.tests.factories import StudyFactory, StudySiteFactory
+from primed.users.tests.factories import UserFactory
 
 from .. import models, tables
 from . import factories
@@ -49,6 +50,14 @@ class SignedAgreementTableTest(TestCase):
         self.assertEqual(table.rows[1].get_cell("number_accessors"), 1)
         self.assertEqual(table.rows[2].get_cell("number_accessors"), 2)
 
+    def test_ordering(self):
+        """Instances are ordered alphabetically by cc_id."""
+        instance_1 = factories.MemberAgreementFactory.create(signed_agreement__cc_id=2)
+        instance_2 = factories.MemberAgreementFactory.create(signed_agreement__cc_id=1)
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2.signed_agreement)
+        self.assertEqual(table.data[1], instance_1.signed_agreement)
+
 
 class MemberAgreementTableTest(TestCase):
     model = models.MemberAgreement
@@ -84,6 +93,14 @@ class MemberAgreementTableTest(TestCase):
         self.assertEqual(table.rows[0].get_cell("number_accessors"), 0)
         self.assertEqual(table.rows[1].get_cell("number_accessors"), 1)
         self.assertEqual(table.rows[2].get_cell("number_accessors"), 2)
+
+    def test_ordering(self):
+        """Instances are ordered alphabetically by cc_id."""
+        instance_1 = self.model_factory.create(signed_agreement__cc_id=2)
+        instance_2 = self.model_factory.create(signed_agreement__cc_id=1)
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
 
 
 class DataAffiliateAgreementTableTest(TestCase):
@@ -121,6 +138,14 @@ class DataAffiliateAgreementTableTest(TestCase):
         self.assertEqual(table.rows[1].get_cell("number_accessors"), 1)
         self.assertEqual(table.rows[2].get_cell("number_accessors"), 2)
 
+    def test_ordering(self):
+        """Instances are ordered alphabetically by cc_id."""
+        instance_1 = self.model_factory.create(signed_agreement__cc_id=2)
+        instance_2 = self.model_factory.create(signed_agreement__cc_id=1)
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
+
 
 class NonDataAffiliateAgreementTableTest(TestCase):
     model = models.NonDataAffiliateAgreement
@@ -156,6 +181,14 @@ class NonDataAffiliateAgreementTableTest(TestCase):
         self.assertEqual(table.rows[0].get_cell("number_accessors"), 0)
         self.assertEqual(table.rows[1].get_cell("number_accessors"), 1)
         self.assertEqual(table.rows[2].get_cell("number_accessors"), 2)
+
+    def test_ordering(self):
+        """Instances are ordered alphabetically by cc_id."""
+        instance_1 = self.model_factory.create(signed_agreement__cc_id=2)
+        instance_2 = self.model_factory.create(signed_agreement__cc_id=1)
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
 
 
 class RepresentativeRecordsTableTest(TestCase):
@@ -203,6 +236,18 @@ class RepresentativeRecordsTableTest(TestCase):
         record = factories.SignedAgreementFactory()
         self.assertIsNone(table.render_signing_group(record))
 
+    def test_ordering(self):
+        """Instances are ordered alphabetically by representative name."""
+        instance_1 = factories.MemberAgreementFactory.create(
+            signed_agreement__representative__name="zzz"
+        )
+        instance_2 = factories.MemberAgreementFactory.create(
+            signed_agreement__representative__name="aaa"
+        )
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2.signed_agreement)
+        self.assertEqual(table.data[1], instance_1.signed_agreement)
+
 
 class StudyRecordsTableTest(TestCase):
     """Tests for the StudyRecordsTable class."""
@@ -224,6 +269,14 @@ class StudyRecordsTableTest(TestCase):
         self.model_factory.create_batch(2)
         table = self.table_class(self.model.objects.all())
         self.assertEqual(len(table.rows), 2)
+
+    def test_ordering(self):
+        """Instances are ordered alphabetically by study short name."""
+        instance_1 = self.model_factory.create(study__short_name="zzz")
+        instance_2 = self.model_factory.create(study__short_name="aaa")
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
 
 
 class UserAccessRecordsTableTest(TestCase):
@@ -308,6 +361,23 @@ class UserAccessRecordsTableTest(TestCase):
         record = GroupAccountMembershipFactory.create(group__signedagreement=agreement)
         self.assertIsNone(table.render_signing_group(record))
 
+    def test_ordering(self):
+        """Instances are ordered alphabetically by user name."""
+        agreement = factories.MemberAgreementFactory.create()
+        user_1 = UserFactory.create(name="zzz")
+        instance_1 = GroupAccountMembershipFactory.create(
+            group__signedagreement=agreement.signed_agreement,
+            account__user=user_1,
+        )
+        user_2 = UserFactory.create(name="aaa")
+        instance_2 = GroupAccountMembershipFactory.create(
+            group__signedagreement=agreement.signed_agreement,
+            account__user=user_2,
+        )
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
+
 
 class CDSAWorkspaceRecordsTableTest(TestCase):
     """Tests for the CDSAWorkspaceRecordsTable class."""
@@ -342,6 +412,19 @@ class CDSAWorkspaceRecordsTableTest(TestCase):
             workspace=cdsa_workspace.workspace, group__name="PRIMED_ALL"
         )
         self.assertNotEqual(table.render_date_shared(cdsa_workspace), "—")
+
+    def test_ordering(self):
+        """Instances are ordered alphabetically by user name."""
+        agreement = factories.DataAffiliateAgreementFactory.create()
+        instance_1 = factories.CDSAWorkspaceFactory.create(
+            study=agreement.study, workspace__name="zzz"
+        )
+        instance_2 = factories.CDSAWorkspaceFactory.create(
+            study=agreement.study, workspace__name="aaa"
+        )
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
 
 
 class CDSAWorkspaceTableTest(TestCase):
@@ -392,3 +475,11 @@ class CDSAWorkspaceTableTest(TestCase):
         )
         table = self.table_class(self.model.objects.all())
         self.assertEqual("", table.rows[0].get_cell_value("is_shared"))
+
+    def test_ordering(self):
+        """Instances are ordered alphabetically by user name."""
+        instance_1 = factories.CDSAWorkspaceFactory.create(workspace__name="zzz")
+        instance_2 = factories.CDSAWorkspaceFactory.create(workspace__name="aaa")
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2.workspace)
+        self.assertEqual(table.data[1], instance_1.workspace)

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -172,11 +172,11 @@ class dbGaPDataAccessSnapshotTable(tables.Table):
     def render_pk(self, record):
         return "See details"
 
-    def render_number_approved_dars(self, value, record):
+    def render_number_approved_dars(self, record):
         n_dars = record.dbgapdataaccessrequest_set.approved().count()
         return n_dars
 
-    def render_number_requested_dars(self, value, record):
+    def render_number_requested_dars(self, record):
         n_dars = record.dbgapdataaccessrequest_set.count()
         return n_dars
 

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -27,6 +27,7 @@ class dbGaPStudyAccessionTable(tables.Table):
             "dbgap_phs",
             "studies",
         )
+        order_by = ("dbgap_phs",)
 
     def render_dbgap_phs(self, value):
         return "phs{0:06d}".format(value)
@@ -140,6 +141,7 @@ class dbGaPApplicationTable(tables.Table):
             "dbgap_project_id",
             "principal_investigator",
         )
+        order_by = ("dbgap_project_id",)
 
 
 class dbGaPDataAccessSnapshotTable(tables.Table):
@@ -151,6 +153,7 @@ class dbGaPDataAccessSnapshotTable(tables.Table):
             "pk",
             "created",
         )
+        order_by = ("-created",)
 
     pk = tables.Column(linkify=True, verbose_name="Details", orderable=False)
     number_approved_dars = tables.columns.Column(
@@ -235,6 +238,7 @@ class dbGaPDataAccessRequestTable(tables.Table):
             "dbgap_consent_abbreviation",
             "dbgap_current_status",
         )
+        order_by = ("dbgap_dar_id",)
 
 
 class dbGaPDataAccessRequestSummaryTable(tables.Table):

--- a/primed/dbgap/tests/test_tables.py
+++ b/primed/dbgap/tests/test_tables.py
@@ -10,6 +10,7 @@ from anvil_consortium_manager.tests.factories import (
 from django.db.models import Count
 from django.test import TestCase
 from django.utils import timezone
+from freezegun import freeze_time
 
 from .. import models, tables
 from . import factories
@@ -49,6 +50,14 @@ class dbGaPStudyAccessionTableTest(TestCase):
         self.assertEqual(table.rows[0].get_cell("number_workspaces"), 0)
         self.assertEqual(table.rows[1].get_cell("number_workspaces"), 1)
         self.assertEqual(table.rows[2].get_cell("number_workspaces"), 2)
+
+    def test_ordering(self):
+        """Instances are ordered alphabetically by dbgap_phs."""
+        instance_1 = self.model_factory.create(dbgap_phs=2)
+        instance_2 = self.model_factory.create(dbgap_phs=1)
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
 
 
 class dbGaPWorkspaceTableTest(TestCase):
@@ -380,6 +389,14 @@ class dbGaPApplicationTableTest(TestCase):
             latest_snapshot.get_absolute_url(), table.rows[0].get_cell("last_update")
         )
 
+    def test_ordering(self):
+        """Instances are ordered alphabetically by dbgap_project_id."""
+        instance_1 = self.model_factory.create(dbgap_project_id=2)
+        instance_2 = self.model_factory.create(dbgap_project_id=1)
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
+
 
 class dbGaPDataAccessSnapshotTableTest(TestCase):
     model = models.dbGaPDataAccessSnapshot
@@ -435,6 +452,16 @@ class dbGaPDataAccessSnapshotTableTest(TestCase):
         table = self.table_class(self.model.objects.all())
         self.assertEqual(table.rows[0].get_cell_value("number_approved_dars"), 1)
         self.assertEqual(table.rows[1].get_cell_value("number_approved_dars"), 2)
+
+    def test_ordering(self):
+        """Instances are ordered by decreasing snapshot date."""
+        with freeze_time("2020-01-01"):
+            instance_1 = self.model_factory.create()
+        with freeze_time("2021-12-12"):
+            instance_2 = self.model_factory.create()
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
 
 
 class dbGaPDataAccessRequestTableTest(TestCase):
@@ -507,6 +534,14 @@ class dbGaPDataAccessRequestTableTest(TestCase):
         value = table.render_matching_workspaces(dar.get_dbgap_workspaces(), dar)
         self.assertIn(str(workspace_1), value)
         self.assertIn(str(workspace_2), value)
+
+    def test_ordering(self):
+        """Instances are ordered alphabetically by dbgap_dar_id."""
+        instance_1 = self.model_factory.create(dbgap_dar_id=2)
+        instance_2 = self.model_factory.create(dbgap_dar_id=1)
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], instance_2)
+        self.assertEqual(table.data[1], instance_1)
 
 
 class dbGaPDataAccessRequestSummaryTable(TestCase):

--- a/primed/dbgap/tests/test_tables.py
+++ b/primed/dbgap/tests/test_tables.py
@@ -418,40 +418,76 @@ class dbGaPDataAccessSnapshotTableTest(TestCase):
         self.assertEqual(len(table.rows), 2)
 
     def test_number_approved_dars(self):
-        snapshot = self.model_factory.create()
+        snapshot_1 = self.model_factory.create()
         factories.dbGaPDataAccessRequestFactory.create(
-            dbgap_data_access_snapshot=snapshot,
+            dbgap_data_access_snapshot=snapshot_1,
             dbgap_current_status=models.dbGaPDataAccessRequest.APPROVED,
         )
         factories.dbGaPDataAccessRequestFactory.create_batch(
             2,
-            dbgap_data_access_snapshot=snapshot,
+            dbgap_data_access_snapshot=snapshot_1,
             dbgap_current_status=models.dbGaPDataAccessRequest.CLOSED,
         )
         factories.dbGaPDataAccessRequestFactory.create_batch(
             2,
-            dbgap_data_access_snapshot=snapshot,
+            dbgap_data_access_snapshot=snapshot_1,
             dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
         )
         factories.dbGaPDataAccessRequestFactory.create_batch(
             2,
-            dbgap_data_access_snapshot=snapshot,
+            dbgap_data_access_snapshot=snapshot_1,
             dbgap_current_status=models.dbGaPDataAccessRequest.EXPIRED,
         )
         factories.dbGaPDataAccessRequestFactory.create_batch(
             2,
-            dbgap_data_access_snapshot=snapshot,
+            dbgap_data_access_snapshot=snapshot_1,
             dbgap_current_status=models.dbGaPDataAccessRequest.NEW,
         )
-        other_snapshot = self.model_factory.create()
+        snapshot_2 = self.model_factory.create()
         factories.dbGaPDataAccessRequestFactory.create_batch(
             2,
-            dbgap_data_access_snapshot=other_snapshot,
+            dbgap_data_access_snapshot=snapshot_2,
             dbgap_current_status=models.dbGaPDataAccessRequest.APPROVED,
         )
         table = self.table_class(self.model.objects.all())
-        self.assertEqual(table.rows[0].get_cell_value("number_approved_dars"), 1)
-        self.assertEqual(table.rows[1].get_cell_value("number_approved_dars"), 2)
+        self.assertEqual(table.render_number_approved_dars(snapshot_1), 1)
+        self.assertEqual(table.render_number_approved_dars(snapshot_2), 2)
+
+    def test_number_requested_dars(self):
+        snapshot_1 = self.model_factory.create()
+        factories.dbGaPDataAccessRequestFactory.create(
+            dbgap_data_access_snapshot=snapshot_1,
+            dbgap_current_status=models.dbGaPDataAccessRequest.APPROVED,
+        )
+        factories.dbGaPDataAccessRequestFactory.create_batch(
+            2,
+            dbgap_data_access_snapshot=snapshot_1,
+            dbgap_current_status=models.dbGaPDataAccessRequest.CLOSED,
+        )
+        factories.dbGaPDataAccessRequestFactory.create_batch(
+            2,
+            dbgap_data_access_snapshot=snapshot_1,
+            dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
+        )
+        factories.dbGaPDataAccessRequestFactory.create_batch(
+            2,
+            dbgap_data_access_snapshot=snapshot_1,
+            dbgap_current_status=models.dbGaPDataAccessRequest.EXPIRED,
+        )
+        factories.dbGaPDataAccessRequestFactory.create_batch(
+            2,
+            dbgap_data_access_snapshot=snapshot_1,
+            dbgap_current_status=models.dbGaPDataAccessRequest.NEW,
+        )
+        snapshot_2 = self.model_factory.create()
+        factories.dbGaPDataAccessRequestFactory.create_batch(
+            2,
+            dbgap_data_access_snapshot=snapshot_2,
+            dbgap_current_status=models.dbGaPDataAccessRequest.APPROVED,
+        )
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.render_number_requested_dars(snapshot_1), 9)
+        self.assertEqual(table.render_number_requested_dars(snapshot_2), 2)
 
     def test_ordering(self):
         """Instances are ordered by decreasing snapshot date."""

--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -91,6 +91,7 @@ class StudySiteTable(tables.Table):
     class Meta:
         model = models.StudySite
         fields = ("short_name", "full_name")
+        order_by = ("short_name",)
 
 
 class AccountTable(tables.Table):

--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -118,6 +118,7 @@ class AvailableDataTable(tables.Table):
     class Meta:
         model = models.AvailableData
         fields = ("name", "description")
+        order_by = ("name",)
 
 
 class DataSummaryTable(tables.Table):

--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -80,6 +80,7 @@ class StudyTable(tables.Table):
     class Meta:
         model = models.Study
         fields = ("short_name", "full_name")
+        order_by = ("short_name",)
 
 
 class StudySiteTable(tables.Table):

--- a/primed/primed_anvil/tests/test_tables.py
+++ b/primed/primed_anvil/tests/test_tables.py
@@ -58,6 +58,14 @@ class StudySiteTableTest(TestCase):
         table = self.table_class(self.model.objects.all())
         self.assertEqual(len(table.rows), 2)
 
+    def test_ordering(self):
+        """Studies are ordered alphabetically by short name"""
+        foo = self.model_factory.create(short_name="foo", full_name="AAA")
+        bar = self.model_factory.create(short_name="bar", full_name="BBB")
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], bar)
+        self.assertEqual(table.data[1], foo)
+
 
 class AccountTableTest(TestCase):
     """Tests for the custom AccountTable."""

--- a/primed/primed_anvil/tests/test_tables.py
+++ b/primed/primed_anvil/tests/test_tables.py
@@ -30,6 +30,14 @@ class StudyTableTest(TestCase):
         table = self.table_class(self.model.objects.all())
         self.assertEqual(len(table.rows), 2)
 
+    def test_ordering(self):
+        """Studies are ordered alphabetically by short name"""
+        study_foo = self.model_factory.create(short_name="foo", full_name="AAA")
+        study_bar = self.model_factory.create(short_name="bar", full_name="BBB")
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], study_bar)
+        self.assertEqual(table.data[1], study_foo)
+
 
 class StudySiteTableTest(TestCase):
     model = models.StudySite

--- a/primed/primed_anvil/tests/test_tables.py
+++ b/primed/primed_anvil/tests/test_tables.py
@@ -132,6 +132,14 @@ class AvailableDataTableTest(TestCase):
         table = self.table_class(self.model.objects.all())
         self.assertEqual(len(table.rows), 2)
 
+    def test_ordering(self):
+        """Instances are ordered alphabetically name."""
+        foo = self.model_factory.create(name="foo", description="AAA")
+        bar = self.model_factory.create(name="bar", description="BBB")
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(table.data[0], bar)
+        self.assertEqual(table.data[1], foo)
+
 
 class DataSummaryTableTest(TestCase):
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -37,3 +37,8 @@ setuptools==65.5.1 # https://github.com/pypa/setuptools
 django-debug-toolbar==3.4.0  # https://github.com/jazzband/django-debug-toolbar
 django-coverage-plugin==2.0.3  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.5.2  # https://github.com/pytest-dev/pytest-django
+
+# My additions
+# ------------------------------------------------------------------------------
+# For setting time when running tests.
+freezegun==1.2.2  # https://github.com/spulec/freezegun


### PR DESCRIPTION
- Add default order_by to the tables in the `primed_anvil`, `dbgap`, and `cdsa` apps.

This makes it easier for users to find what they're looking for, compared to when tables were just sorted by pk.

Closes #227