### PR TITLE
Make the dbGaP DAR table more compact

### DIFF
--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -184,13 +184,28 @@ class dbGaPDataAccessSnapshotTable(tables.Table):
 class dbGaPDataAccessRequestTable(tables.Table):
     """Class to render a table of dbGaPDataAccessRequest objects."""
 
+    dbgap_dar_id = tables.columns.Column(verbose_name="DAR")
+    dbgap_dac = tables.columns.Column(verbose_name="DAC")
     dbgap_accession = tables.columns.Column(
-        verbose_name=" dbGaP accession",
+        verbose_name="Accession",
         accessor="get_dbgap_accession",
     )
+    dbgap_consent_abbreviation = tables.columns.Column(verbose_name="Consent")
+    dbgap_current_status = tables.columns.Column(verbose_name="Current status")
     matching_workspaces = tables.columns.Column(
         accessor="get_dbgap_workspaces", orderable=False, default=" "
     )
+
+    class Meta:
+        model = models.dbGaPDataAccessRequest
+        fields = (
+            "dbgap_dar_id",
+            "dbgap_dac",
+            "dbgap_accession",
+            "dbgap_consent_abbreviation",
+            "dbgap_current_status",
+        )
+        order_by = ("dbgap_dar_id",)
 
     def render_matching_workspaces(self, value, record):
         template_code = """
@@ -226,17 +241,8 @@ class dbGaPDataAccessRequestTable(tables.Table):
             )
         )
 
-    class Meta:
-        model = models.dbGaPDataAccessRequest
-        fields = (
-            "dbgap_dar_id",
-            "dbgap_dac",
-            "dbgap_accession",
-            "dbgap_consent_code",
-            "dbgap_consent_abbreviation",
-            "dbgap_current_status",
-        )
-        order_by = ("dbgap_dar_id",)
+    # def render_consent(self, record):
+    #     return "{} ({})".format(record.dbgap_consent_abbreviation, record.dbgap_consent_code)
 
 
 class dbGaPDataAccessRequestSummaryTable(tables.Table):

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -207,7 +207,7 @@ class dbGaPDataAccessRequestTable(tables.Table):
             )
             this_context = {
                 "has_access": has_access,
-                "workspace": dbgap_workspace,
+                "workspace": dbgap_workspace.workspace.name,
             }
             this = Template(template_code).render(Context(this_context))
             items = items + [this]

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -233,7 +233,7 @@ class dbGaPDataAccessRequestTable(tables.Table):
 
     def render_dbgap_accession(self, value, record):
         return format_html(
-            """<a href="{}" target="_blank">{}<i class="bi bi-box-arrow-up-right ms-2"></i></a>
+            """<a href="{}" target="_blank">{}<sup><i class="bi bi-box-arrow-up-right ms-1"></i></sup></a>
             """.format(
                 record.get_dbgap_link(), value
             )

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -233,10 +233,7 @@ class dbGaPDataAccessRequestTable(tables.Table):
 
     def render_dbgap_accession(self, value, record):
         return format_html(
-            """<a href="{}" target="_blank">
-              {}
-              <i class="bi bi-box-arrow-up-right"></i>
-            </a>
+            """<a href="{}" target="_blank">{}<i class="bi bi-box-arrow-up-right ms-2"></i></a>
             """.format(
                 record.get_dbgap_link(), value
             )

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -194,11 +194,9 @@ class dbGaPDataAccessRequestTable(tables.Table):
 
     def render_matching_workspaces(self, value, record):
         template_code = """
-        <li>
-            <a href="{{workspace.get_absolute_url}}">{{workspace}}</a>
-            <i class="bi bi-{% if has_access %}check-circle-fill"
-            style="color: green{% else %}x-square-fill" style="color: red{% endif %};"></i>
-        </li>
+        <i class="bi bi-{% if has_access %}check-circle-fill"
+        style="color: green{% else %}x-square-fill" style="color: red{% endif %};"></i>
+        <a href="{{workspace.get_absolute_url}}">{{workspace}}</a>
         """
         items = []
         for dbgap_workspace in value:
@@ -211,7 +209,7 @@ class dbGaPDataAccessRequestTable(tables.Table):
             }
             this = Template(template_code).render(Context(this_context))
             items = items + [this]
-        html = format_html("<ul>" + " ".join(items) + "</ul>")
+        html = format_html("" + "<br>".join(items))
         return html
 
     def render_dbgap_phs(self, value):

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -206,6 +206,7 @@ class dbGaPDataAccessRequestTable(tables.Table):
             "dbgap_current_status",
         )
         order_by = ("dbgap_dar_id",)
+        attrs = {"class": "table table-sm"}
 
     def render_matching_workspaces(self, value, record):
         template_code = """

--- a/primed/dbgap/tests/test_tables.py
+++ b/primed/dbgap/tests/test_tables.py
@@ -531,7 +531,8 @@ class dbGaPDataAccessRequestTableTest(TestCase):
         )
         table = self.table_class([dar])
         value = table.render_matching_workspaces(dar.get_dbgap_workspaces(), dar)
-        self.assertIn(str(workspace), value)
+        self.assertIn(workspace.workspace.name, value)
+        self.assertNotIn(workspace.workspace.billing_project.name, value)
         self.assertIn("circle-fill", value)
 
     def test_one_matching_workspace_without_access(self):
@@ -542,7 +543,7 @@ class dbGaPDataAccessRequestTableTest(TestCase):
         )
         table = self.table_class([dar])
         value = table.render_matching_workspaces(dar.get_dbgap_workspaces(), dar)
-        self.assertIn(str(workspace), value)
+        self.assertIn(workspace.workspace.name, value)
         self.assertIn("square-fill", value)
 
     def test_two_matching_workspaces(self):
@@ -568,8 +569,8 @@ class dbGaPDataAccessRequestTableTest(TestCase):
         )
         table = self.table_class([dar])
         value = table.render_matching_workspaces(dar.get_dbgap_workspaces(), dar)
-        self.assertIn(str(workspace_1), value)
-        self.assertIn(str(workspace_2), value)
+        self.assertIn(workspace_1.workspace.name, value)
+        self.assertIn(workspace_2.workspace.name, value)
 
     def test_ordering(self):
         """Instances are ordered alphabetically by dbgap_dar_id."""

--- a/primed/templates/dbgap/dbgapdataaccesssnapshot_detail.html
+++ b/primed/templates/dbgap/dbgapdataaccesssnapshot_detail.html
@@ -36,12 +36,12 @@
   <div class="accordion my-3" id="accordionDARs">
     <div class="accordion-item">
       <h2 class="accordion-header" id="headingOne">
-        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
           <span class="fa-solid fa-table-list mx-1"></span>
           Data access requests
         </button>
       </h2>
-      <div id="collapseOne" class="accordion-collapse collapse" aria-labelledby="headingOne" data-bs-parent="#accordionDARs">
+      <div id="collapseOne" class="accordion-collapse show" aria-labelledby="headingOne" data-bs-parent="#accordionDARs">
         <div class="accordion-body">
           {% render_table data_access_request_table %}
         </div>


### PR DESCRIPTION
- Use short names for columns
- Remove columns
- Show only workspace name instead of billing project + name
- Smaller bootstrap/html formatting