### PR TITLE
Add a public dbGaP records page

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -308,6 +308,7 @@ LOGIN_REQUIRED_IGNORE_VIEW_NAMES = [
     "cdsa:records:studies",
     "cdsa:records:workspaces",
     "cdsa:records:user_access",
+    "dbgap:records:index",
 ]
 
 # django-dbbackup

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -309,6 +309,7 @@ LOGIN_REQUIRED_IGNORE_VIEW_NAMES = [
     "cdsa:records:workspaces",
     "cdsa:records:user_access",
     "dbgap:records:index",
+    "dbgap:records:applications",
 ]
 
 # django-dbbackup

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -330,3 +330,40 @@ class dbGaPDataAccessRequestSummaryTable(tables.Table):
         model = models.dbGaPDataAccessRequest
         fields = ("dbgap_dac", "dbgap_current_status", "total")
         attrs = {"class": "table table-sm"}
+
+
+class dbGaPApplicationRecordsTable(tables.Table):
+    """Class to render a publicly-viewable table of dbGaPApplication objects."""
+
+    dbgap_project_id = tables.columns.Column()
+    principal_investigator = tables.columns.Column(
+        verbose_name="Application PI",
+        accessor="principal_investigator__name",
+    )
+    principal_investigator__study_sites = tables.columns.ManyToManyColumn(
+        verbose_name="Study site(s)",
+    )
+    number_approved_dars = tables.columns.ManyToManyColumn(
+        accessor="dbgapdataaccesssnapshot_set",
+        filter=lambda qs: qs.filter(is_most_recent=True),
+        verbose_name="Number of approved DARs",
+        transform=lambda obj: obj.dbgapdataaccessrequest_set.approved().count(),
+    )
+    number_requested_dars = tables.columns.ManyToManyColumn(
+        accessor="dbgapdataaccesssnapshot_set",
+        filter=lambda qs: qs.filter(is_most_recent=True),
+        verbose_name="Number of requested DARs",
+        transform=lambda obj: obj.dbgapdataaccessrequest_set.count(),
+    )
+    last_update = ManyToManyDateTimeColumn(
+        accessor="dbgapdataaccesssnapshot_set",
+        filter=lambda qs: qs.filter(is_most_recent=True),
+    )
+
+    class Meta:
+        model = models.dbGaPApplication
+        fields = (
+            "dbgap_project_id",
+            "principal_investigator",
+        )
+        order_by = ("dbgap_project_id",)

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -4216,3 +4216,36 @@ class dbGaPWorkspaceAuditTest(TestCase):
             audit.dbGaPWorkspaceAccessAudit.ERROR_HAS_ACCESS,
         )
         self.assertIsNotNone(table.rows[0].get_cell_value("action"))
+
+
+class dbGaPRecordsIndexTest(TestCase):
+    """Tests for the dbGaPRecordsIndex view."""
+
+    def setUp(self):
+        """Set up test class."""
+        self.factory = RequestFactory()
+        # Create a user with both view and edit permission.
+        self.user = User.objects.create_user(username="test", password="test")
+
+    def get_url(self, *args):
+        """Get the url for the view being tested."""
+        return reverse("dbgap:records:index", args=args)
+
+    def test_status_code_not_logged_in(self):
+        "View redirects to login view when user is not logged in."
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_status_code_user_logged_in(self):
+        """Returns successful response code."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_links(self):
+        """response includes the correct links."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url())
+        self.assertContains(response, reverse("dbgap:records:applications"))
+        # self.assertContains(response, reverse("cdsa:records:user_access"))
+        # self.assertContains(response, reverse("cdsa:records:workspaces"))

--- a/primed/dbgap/urls.py
+++ b/primed/dbgap/urls.py
@@ -80,6 +80,11 @@ dbgap_workspace_patterns = (
 records_patterns = (
     [
         path("", views.dbGaPRecordsIndex.as_view(), name="index"),
+        path(
+            "applications/",
+            views.dbGaPApplicationRecords.as_view(),
+            name="applications",
+        ),
     ],
     "records",
 )

--- a/primed/dbgap/urls.py
+++ b/primed/dbgap/urls.py
@@ -76,8 +76,18 @@ dbgap_workspace_patterns = (
     ],
     "workspaces",
 )
+
+records_patterns = (
+    [
+        path("", views.dbGaPRecordsIndex.as_view(), name="index"),
+    ],
+    "records",
+)
+
+
 urlpatterns = [
     path("studies/", include(dbgap_study_accession_patterns)),
     path("applications/", include(dbgap_application_patterns)),
     path("workspaces/", include(dbgap_workspace_patterns)),
+    path("records/", include(records_patterns)),
 ]

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -22,7 +22,13 @@ from django.db.utils import IntegrityError
 from django.http import Http404
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import CreateView, DetailView, FormView, UpdateView
+from django.views.generic import (
+    CreateView,
+    DetailView,
+    FormView,
+    TemplateView,
+    UpdateView,
+)
 from django_tables2 import SingleTableMixin, SingleTableView
 from django_tables2.export.views import ExportMixin
 
@@ -570,3 +576,9 @@ class dbGaPWorkspaceAudit(AnVILConsortiumManagerViewRequired, DetailView):
         context["needs_action_table"] = data_access_audit.get_needs_action_table()
         context["data_access_audit"] = data_access_audit
         return context
+
+
+class dbGaPRecordsIndex(TemplateView):
+    """Index page for dbGaP records."""
+
+    template_name = "dbgap/records_index.html"

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -582,3 +582,11 @@ class dbGaPRecordsIndex(TemplateView):
     """Index page for dbGaP records."""
 
     template_name = "dbgap/records_index.html"
+
+
+class dbGaPApplicationRecords(SingleTableView):
+    """Display a public list of dbGaP applications."""
+
+    model = models.dbGaPApplication
+    template_name = "dbgap/dbgapapplication_records.html"
+    table_class = tables.dbGaPApplicationRecordsTable

--- a/primed/templates/dbgap/dbgapapplication_records.html
+++ b/primed/templates/dbgap/dbgapapplication_records.html
@@ -1,0 +1,15 @@
+{% extends "anvil_consortium_manager/base.html" %}
+{% load render_table from django_tables2 %}
+
+{% block title %}dbGaP application records{% endblock %}
+
+{% block content %}
+<h1>dbGaP application records</h1>
+
+<div class="">
+  <p>The following table shows the list of PRIMED coordinated dbGaP applications that the Coordinating Center is tracking as of {% now "SHORT_DATETIME_FORMAT" %}.</p>
+</div>
+
+{% render_table table %}
+
+{% endblock content %}

--- a/primed/templates/dbgap/records_index.html
+++ b/primed/templates/dbgap/records_index.html
@@ -1,0 +1,27 @@
+{% extends "anvil_consortium_manager/base.html" %}
+
+{% block title %}dbGaP records{% endblock %}
+
+{% block content %}
+<h1>dbGaP records</h1>
+
+
+   <div class="row g-4 py-2 mx-4 row-cols-2">
+
+     <div class="col d-flex align-items-start">
+       <div class="icon-square text-dark flex-shrink-0 me-3">
+         <h2><span class="fa-solid fa-handshake-simple mx-2"></span></h2>
+       </div>
+       <div>
+         <h2>dbGaP coordinated applications</h2>
+         <p>View dbGaP coordinated applications for PRIMED.</p>
+         <a href="#" class="btn btn-primary">
+           View applications
+         </a>
+       </div>
+     </div>
+
+   </div>
+
+
+{% endblock content %}

--- a/primed/templates/dbgap/records_index.html
+++ b/primed/templates/dbgap/records_index.html
@@ -15,7 +15,7 @@
        <div>
          <h2>dbGaP coordinated applications</h2>
          <p>View dbGaP coordinated applications for PRIMED.</p>
-         <a href="#" class="btn btn-primary">
+         <a href="{% url 'dbgap:records:applications' %}" class="btn btn-primary">
            View applications
          </a>
        </div>


### PR DESCRIPTION
These records pages are similar to the CDSA records.

- Add a records index page
- Add a dbGaP applications records page

Closes #262 