### PR TITLE
Add argon2-cffi back to requirements

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -5,6 +5,9 @@ pip-tools
 whitenoise  # https://github.com/evansd/whitenoise
 oauthlib  # https://github.com/oauthlib/oauthlib
 
+# Password hashing
+argon2-cffi # https://github.com/hynek/argon2_cffi
+
 # Django
 # ------------------------------------------------------------------------------
 django>=4.2,<5.0  # https://www.djangoproject.com/

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements/requirements.in
 #
+argon2-cffi==23.1.0
+    # via -r requirements/requirements.in
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
 asgiref==3.7.2
     # via django
 attrs==23.1.0
@@ -21,7 +25,9 @@ certifi==2023.11.17
     #   -r requirements/requirements.in
     #   requests
 cffi==1.15.0
-    # via cryptography
+    # via
+    #   argon2-cffi-bindings
+    #   cryptography
 chardet==5.1.0
     # via pronto
 charset-normalizer==2.0.12


### PR DESCRIPTION
Necessary for logging in via the admin interface.