### PR TITLE
Update to ACM v0.21 and open more views to logged in users

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -370,14 +370,14 @@ DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap4.html"
 ANVIL_API_SERVICE_ACCOUNT_FILE = env("ANVIL_API_SERVICE_ACCOUNT_FILE")
 # Specify workspace adapters.
 ANVIL_WORKSPACE_ADAPTERS = [
-    "primed.miscellaneous_workspaces.adapters.TemplateWorkspaceAdapter",
     "primed.dbgap.adapters.dbGaPWorkspaceAdapter",
     "primed.cdsa.adapters.CDSAWorkspaceAdapter",
-    "primed.miscellaneous_workspaces.adapters.ConsortiumDevelWorkspaceAdapter",
-    "primed.miscellaneous_workspaces.adapters.DataPrepWorkspaceAdapter",
-    "primed.miscellaneous_workspaces.adapters.ResourceWorkspaceAdapter",
-    "primed.miscellaneous_workspaces.adapters.SimulatedDataWorkspaceAdapter",
     "primed.miscellaneous_workspaces.adapters.OpenAccessWorkspaceAdapter",
+    "primed.miscellaneous_workspaces.adapters.SimulatedDataWorkspaceAdapter",
+    "primed.miscellaneous_workspaces.adapters.ResourceWorkspaceAdapter",
+    "primed.miscellaneous_workspaces.adapters.ConsortiumDevelWorkspaceAdapter",
+    "primed.miscellaneous_workspaces.adapters.TemplateWorkspaceAdapter",
+    "primed.miscellaneous_workspaces.adapters.DataPrepWorkspaceAdapter",
 ]
 ANVIL_ACCOUNT_ADAPTER = "primed.primed_anvil.adapters.AccountAdapter"
 

--- a/primed/cdsa/adapters.py
+++ b/primed/cdsa/adapters.py
@@ -12,7 +12,8 @@ class CDSAWorkspaceAdapter(BaseWorkspaceAdapter):
     description = (
         "Workspaces containing data from the Consortium Data Sharing Agreement."
     )
-    list_table_class = tables.CDSAWorkspaceTable
+    list_table_class_staff_view = tables.CDSAWorkspaceTable
+    list_table_class_view = tables.CDSAWorkspaceTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.CDSAWorkspace
     workspace_data_form_class = forms.CDSAWorkspaceForm

--- a/primed/cdsa/adapters.py
+++ b/primed/cdsa/adapters.py
@@ -10,7 +10,7 @@ class CDSAWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "cdsa"
     name = "CDSA workspace"
     description = (
-        "Workspaces containing data from the Consortium Data Sharing Agreement."
+        "Workspaces containing data from the Consortium Data Sharing Agreement"
     )
     list_table_class_staff_view = tables.CDSAWorkspaceStaffTable
     list_table_class_view = tables.CDSAWorkspaceUserTable

--- a/primed/cdsa/adapters.py
+++ b/primed/cdsa/adapters.py
@@ -12,8 +12,8 @@ class CDSAWorkspaceAdapter(BaseWorkspaceAdapter):
     description = (
         "Workspaces containing data from the Consortium Data Sharing Agreement."
     )
-    list_table_class_staff_view = tables.CDSAWorkspaceTable
-    list_table_class_view = tables.CDSAWorkspaceTable
+    list_table_class_staff_view = tables.CDSAWorkspaceStaffTable
+    list_table_class_view = tables.CDSAWorkspaceStaffTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.CDSAWorkspace
     workspace_data_form_class = forms.CDSAWorkspaceForm

--- a/primed/cdsa/adapters.py
+++ b/primed/cdsa/adapters.py
@@ -13,7 +13,7 @@ class CDSAWorkspaceAdapter(BaseWorkspaceAdapter):
         "Workspaces containing data from the Consortium Data Sharing Agreement."
     )
     list_table_class_staff_view = tables.CDSAWorkspaceStaffTable
-    list_table_class_view = tables.CDSAWorkspaceStaffTable
+    list_table_class_view = tables.CDSAWorkspaceUserTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.CDSAWorkspace
     workspace_data_form_class = forms.CDSAWorkspaceForm

--- a/primed/cdsa/tables.py
+++ b/primed/cdsa/tables.py
@@ -295,7 +295,7 @@ class CDSAWorkspaceRecordsTable(tables.Table):
             return "—"
 
 
-class CDSAWorkspaceTable(tables.Table):
+class CDSAWorkspaceStaffTable(tables.Table):
     """A table for the CDSAWorkspace model."""
 
     name = tables.Column(linkify=True)
@@ -324,7 +324,7 @@ class CDSAWorkspaceTable(tables.Table):
         order_by = ("name",)
 
 
-class CDSAWorkspaceLimitedViewTable(tables.Table):
+class CDSAWorkspaceUserTable(tables.Table):
     """A table for the CDSAWorkspace model."""
 
     name = tables.Column()

--- a/primed/cdsa/tables.py
+++ b/primed/cdsa/tables.py
@@ -327,7 +327,7 @@ class CDSAWorkspaceStaffTable(tables.Table):
 class CDSAWorkspaceUserTable(tables.Table):
     """A table for the CDSAWorkspace model."""
 
-    name = tables.Column()
+    name = tables.Column(linkify=True)
     billing_project = tables.Column()
     cdsaworkspace__data_use_permission__abbreviation = tables.Column(
         verbose_name="DUO permission",

--- a/primed/cdsa/tests/test_tables.py
+++ b/primed/cdsa/tests/test_tables.py
@@ -447,12 +447,12 @@ class CDSAWorkspaceRecordsTableTest(TestCase):
         self.assertEqual(table.data[1], instance_1)
 
 
-class CDSAWorkspaceTableTest(TestCase):
-    """Tests for the CDSAWorkspaceTable class."""
+class CDSAWorkspaceStaffTableTest(TestCase):
+    """Tests for the CDSAWorkspaceStaffTable class."""
 
     model = Workspace
     model_factory = factories.CDSAWorkspaceFactory
-    table_class = tables.CDSAWorkspaceTable
+    table_class = tables.CDSAWorkspaceStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())
@@ -477,12 +477,12 @@ class CDSAWorkspaceTableTest(TestCase):
         self.assertEqual(table.data[1], instance_1.workspace)
 
 
-class CDSAWorkspaceLimitedViewTableTest(TestCase):
-    """Tests for the CDSAWorkspaceLimitedViewTable class."""
+class CDSAWorkspaceUserTableTest(TestCase):
+    """Tests for the CDSAWorkspaceUserTable class."""
 
     model = Workspace
     model_factory = factories.CDSAWorkspaceFactory
-    table_class = tables.CDSAWorkspaceLimitedViewTable
+    table_class = tables.CDSAWorkspaceUserTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())

--- a/primed/dbgap/adapters.py
+++ b/primed/dbgap/adapters.py
@@ -10,8 +10,8 @@ class dbGaPWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "dbgap"
     name = "dbGaP workspace"
     description = "Workspaces containing data from released dbGaP accessions"
-    list_table_class_staff_view = tables.dbGaPWorkspaceTable
-    list_table_class_view = tables.dbGaPWorkspaceTable
+    list_table_class_staff_view = tables.dbGaPWorkspaceStaffTable
+    list_table_class_view = tables.dbGaPWorkspaceStaffTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.dbGaPWorkspace
     workspace_data_form_class = forms.dbGaPWorkspaceForm

--- a/primed/dbgap/adapters.py
+++ b/primed/dbgap/adapters.py
@@ -11,7 +11,7 @@ class dbGaPWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "dbGaP workspace"
     description = "Workspaces containing data from released dbGaP accessions"
     list_table_class_staff_view = tables.dbGaPWorkspaceStaffTable
-    list_table_class_view = tables.dbGaPWorkspaceStaffTable
+    list_table_class_view = tables.dbGaPWorkspaceUserTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.dbGaPWorkspace
     workspace_data_form_class = forms.dbGaPWorkspaceForm

--- a/primed/dbgap/adapters.py
+++ b/primed/dbgap/adapters.py
@@ -10,7 +10,8 @@ class dbGaPWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "dbgap"
     name = "dbGaP workspace"
     description = "Workspaces containing data from released dbGaP accessions"
-    list_table_class = tables.dbGaPWorkspaceTable
+    list_table_class_staff_view = tables.dbGaPWorkspaceTable
+    list_table_class_view = tables.dbGaPWorkspaceTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.dbGaPWorkspace
     workspace_data_form_class = forms.dbGaPWorkspaceForm

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -119,7 +119,7 @@ class dbGaPWorkspaceStaffTable(tables.Table):
 class dbGaPWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with dbGaPWorkspace workspace data."""
 
-    name = tables.columns.Column()
+    name = tables.columns.Column(linkify=True)
     billing_project = tables.Column()
     dbgap_accession = dbGaPAccessionColumn(
         accessor="dbgapworkspace__get_dbgap_accession",

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -71,7 +71,7 @@ class dbGaPStudyAccessionTable(tables.Table):
         return "phs{0:06d}".format(value)
 
 
-class dbGaPWorkspaceTable(tables.Table):
+class dbGaPWorkspaceStaffTable(tables.Table):
     """Class to render a table of Workspace objects with dbGaPWorkspace workspace data."""
 
     name = tables.columns.Column(linkify=True)
@@ -116,7 +116,7 @@ class dbGaPWorkspaceTable(tables.Table):
         return n
 
 
-class dbGaPWorkspaceLimitedViewTable(tables.Table):
+class dbGaPWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with dbGaPWorkspace workspace data."""
 
     name = tables.columns.Column()

--- a/primed/dbgap/tests/test_tables.py
+++ b/primed/dbgap/tests/test_tables.py
@@ -116,10 +116,10 @@ class dbGaPStudyAccessionTableTest(TestCase):
         self.assertEqual(table.data[1], instance_1)
 
 
-class dbGaPWorkspaceTableTest(TestCase):
+class dbGaPWorkspaceStaffTableTest(TestCase):
     model = acm_models.Workspace
     model_factory = factories.dbGaPWorkspaceFactory
-    table_class = tables.dbGaPWorkspaceTable
+    table_class = tables.dbGaPWorkspaceStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())
@@ -206,10 +206,10 @@ class dbGaPWorkspaceTableTest(TestCase):
     #     self.assertEqual("", table.rows[0].get_cell_value("is_shared"))
 
 
-class dbGaPWorkspaceLimitedViewTableTest(TestCase):
+class dbGaPWorkspaceUserTableTest(TestCase):
     model = acm_models.Workspace
     model_factory = factories.dbGaPWorkspaceFactory
-    table_class = tables.dbGaPWorkspaceTable
+    table_class = tables.dbGaPWorkspaceStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -267,7 +267,7 @@ class dbGaPStudyAccessionDetailTest(TestCase):
         response = self.get_view()(request, dbgap_phs=self.obj.dbgap_phs)
         self.assertIn("workspace_table", response.context_data)
         self.assertIsInstance(
-            response.context_data["workspace_table"], tables.dbGaPWorkspaceTable
+            response.context_data["workspace_table"], tables.dbGaPWorkspaceStaffTable
         )
 
     def test_workspace_table_none(self):
@@ -856,7 +856,7 @@ class dbGaPWorkspaceListTest(TestCase):
         response = self.get_view()(request, workspace_type=self.workspace_type)
         self.assertIn("table", response.context_data)
         self.assertIsInstance(
-            response.context_data["table"], tables.dbGaPWorkspaceTable
+            response.context_data["table"], tables.dbGaPWorkspaceStaffTable
         )
 
 

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -57,7 +57,7 @@ class dbGaPStudyAccessionDetail(
         return obj
 
     def get_table(self):
-        return tables.dbGaPWorkspaceTable(
+        return tables.dbGaPWorkspaceStaffTable(
             Workspace.objects.filter(dbgapworkspace__dbgap_study_accession=self.object),
             exclude=(
                 "dbgapworkspace__dbgap_study_accession__study",

--- a/primed/duo/tests/test_views.py
+++ b/primed/duo/tests/test_views.py
@@ -19,7 +19,7 @@ class DataUsePermissionListTest(TestCase):
     def setUp(self):
         """Set up test class."""
         self.factory = RequestFactory()
-        # Create a user with both view and edit permission.
+        # Create a user with staff view permission.
         self.user = UserFactory.create(username="test", password="test")
         self.user.user_permissions.add(
             Permission.objects.get(
@@ -122,11 +122,11 @@ class DataUsePermissionDetailTest(TestCase):
     def setUp(self):
         """Set up test class."""
         self.factory = RequestFactory()
-        # Create a user with both view and edit permission.
+        # Create a user with view permission.
         self.user = UserFactory.create(username="test", password="test")
         self.user.user_permissions.add(
             Permission.objects.get(
-                codename=AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME
+                codename=AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
             )
         )
 
@@ -282,7 +282,7 @@ class DataUseModifierDetailTest(TestCase):
         self.user = UserFactory.create(username="test", password="test")
         self.user.user_permissions.add(
             Permission.objects.get(
-                codename=AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME
+                codename=AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
             )
         )
 

--- a/primed/duo/views.py
+++ b/primed/duo/views.py
@@ -1,4 +1,7 @@
-from anvil_consortium_manager.auth import AnVILConsortiumManagerStaffViewRequired
+from anvil_consortium_manager.auth import (
+    AnVILConsortiumManagerStaffViewRequired,
+    AnVILConsortiumManagerViewRequired,
+)
 from django.http import Http404
 from django.views.generic import DetailView, ListView
 
@@ -18,7 +21,7 @@ class DataUsePermissionList(AnVILConsortiumManagerStaffViewRequired, ListView):
         return context
 
 
-class DataUsePermissionDetail(AnVILConsortiumManagerStaffViewRequired, DetailView):
+class DataUsePermissionDetail(AnVILConsortiumManagerViewRequired, DetailView):
 
     model = models.DataUsePermission
 
@@ -51,7 +54,7 @@ class DataUseModifierList(AnVILConsortiumManagerStaffViewRequired, ListView):
         return context
 
 
-class DataUseModifierDetail(AnVILConsortiumManagerStaffViewRequired, DetailView):
+class DataUseModifierDetail(AnVILConsortiumManagerViewRequired, DetailView):
 
     model = models.DataUseModifier
 

--- a/primed/miscellaneous_workspaces/adapters.py
+++ b/primed/miscellaneous_workspaces/adapters.py
@@ -73,7 +73,7 @@ class OpenAccessWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "Open access workspace"
     description = "Workspaces containing open access data"
     list_table_class_staff_view = tables.OpenAccessWorkspaceStaffTable
-    list_table_class_view = tables.OpenAccessWorkspaceStaffTable
+    list_table_class_view = tables.OpenAccessWorkspaceUserTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.OpenAccessWorkspace
     workspace_data_form_class = forms.OpenAccessWorkspaceForm

--- a/primed/miscellaneous_workspaces/adapters.py
+++ b/primed/miscellaneous_workspaces/adapters.py
@@ -72,8 +72,8 @@ class OpenAccessWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "open_access"
     name = "Open access workspace"
     description = "Workspaces containing open access data"
-    list_table_class_staff_view = tables.OpenAccessWorkspaceTable
-    list_table_class_view = tables.OpenAccessWorkspaceTable
+    list_table_class_staff_view = tables.OpenAccessWorkspaceStaffTable
+    list_table_class_view = tables.OpenAccessWorkspaceStaffTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.OpenAccessWorkspace
     workspace_data_form_class = forms.OpenAccessWorkspaceForm

--- a/primed/miscellaneous_workspaces/adapters.py
+++ b/primed/miscellaneous_workspaces/adapters.py
@@ -14,7 +14,8 @@ class SimulatedDataWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "simulated_data"
     name = "Simulated Data workspace"
     description = "Workspaces containing simulated data"
-    list_table_class = DefaultWorkspaceTable
+    list_table_class_staff_view = DefaultWorkspaceTable
+    list_table_class_view = DefaultWorkspaceTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.SimulatedDataWorkspace
     workspace_data_form_class = forms.SimulatedDataWorkspaceForm
@@ -29,7 +30,8 @@ class ConsortiumDevelWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "devel"
     name = "Consortium development workspace"
     description = "Workspaces intended for consortium development of methods"
-    list_table_class = DefaultWorkspaceTable
+    list_table_class_staff_view = DefaultWorkspaceTable
+    list_table_class_view = DefaultWorkspaceTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.ConsortiumDevelWorkspace
     workspace_data_form_class = forms.ConsortiumDevelWorkspaceForm
@@ -42,7 +44,8 @@ class ResourceWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "resource"
     name = "Resource workspace"
     description = "Workspaces containing consortium resources (e.g., examples of using AnVIL, data inventories)"
-    list_table_class = DefaultWorkspaceTable
+    list_table_class_staff_view = DefaultWorkspaceTable
+    list_table_class_view = DefaultWorkspaceTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.ResourceWorkspace
     workspace_data_form_class = forms.ResourceWorkspaceForm
@@ -55,7 +58,8 @@ class TemplateWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "template"
     name = "Template workspace"
     description = "Template workspaces that can be cloned to create other workspaces"
-    list_table_class = DefaultWorkspaceTable
+    list_table_class_staff_view = DefaultWorkspaceTable
+    list_table_class_view = DefaultWorkspaceTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.TemplateWorkspace
     workspace_data_form_class = forms.TemplateWorkspaceForm
@@ -68,7 +72,8 @@ class OpenAccessWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "open_access"
     name = "Open access workspace"
     description = "Workspaces containing open access data"
-    list_table_class = tables.OpenAccessWorkspaceTable
+    list_table_class_staff_view = tables.OpenAccessWorkspaceTable
+    list_table_class_view = tables.OpenAccessWorkspaceTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.OpenAccessWorkspace
     workspace_data_form_class = forms.OpenAccessWorkspaceForm
@@ -83,7 +88,8 @@ class DataPrepWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "data_prep"
     name = "Data prep workspace"
     description = "Workspaces used to prepare data."
-    list_table_class = tables.DataPrepWorkspaceTable
+    list_table_class_staff_view = tables.DataPrepWorkspaceTable
+    list_table_class_view = tables.DataPrepWorkspaceTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.DataPrepWorkspace
     workspace_data_form_class = forms.DataPrepWorkspaceForm

--- a/primed/miscellaneous_workspaces/adapters.py
+++ b/primed/miscellaneous_workspaces/adapters.py
@@ -60,7 +60,9 @@ class TemplateWorkspaceAdapter(BaseWorkspaceAdapter):
 
     type = "template"
     name = "Template workspace"
-    description = "Template workspaces that can be cloned to create other workspaces"
+    description = (
+        "Template workspaces that will be cloned by the CC to create other workspaces"
+    )
     list_table_class_staff_view = DefaultWorkspaceStaffTable
     list_table_class_view = DefaultWorkspaceUserTable
     workspace_form_class = WorkspaceForm
@@ -90,7 +92,7 @@ class DataPrepWorkspaceAdapter(BaseWorkspaceAdapter):
 
     type = "data_prep"
     name = "Data prep workspace"
-    description = "Workspaces used to prepare data."
+    description = "Workspaces used to prepare data for sharing or update data that is already shared"
     list_table_class_staff_view = tables.DataPrepWorkspaceTable
     list_table_class_view = tables.DataPrepWorkspaceTable
     workspace_form_class = WorkspaceForm

--- a/primed/miscellaneous_workspaces/adapters.py
+++ b/primed/miscellaneous_workspaces/adapters.py
@@ -3,7 +3,10 @@
 from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
 from anvil_consortium_manager.forms import WorkspaceForm
 
-from primed.primed_anvil.tables import DefaultWorkspaceTable
+from primed.primed_anvil.tables import (
+    DefaultWorkspaceStaffTable,
+    DefaultWorkspaceUserTable,
+)
 
 from . import forms, models, tables
 
@@ -14,8 +17,8 @@ class SimulatedDataWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "simulated_data"
     name = "Simulated Data workspace"
     description = "Workspaces containing simulated data"
-    list_table_class_staff_view = DefaultWorkspaceTable
-    list_table_class_view = DefaultWorkspaceTable
+    list_table_class_staff_view = DefaultWorkspaceStaffTable
+    list_table_class_view = DefaultWorkspaceUserTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.SimulatedDataWorkspace
     workspace_data_form_class = forms.SimulatedDataWorkspaceForm
@@ -30,8 +33,8 @@ class ConsortiumDevelWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "devel"
     name = "Consortium development workspace"
     description = "Workspaces intended for consortium development of methods"
-    list_table_class_staff_view = DefaultWorkspaceTable
-    list_table_class_view = DefaultWorkspaceTable
+    list_table_class_staff_view = DefaultWorkspaceStaffTable
+    list_table_class_view = DefaultWorkspaceUserTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.ConsortiumDevelWorkspace
     workspace_data_form_class = forms.ConsortiumDevelWorkspaceForm
@@ -44,8 +47,8 @@ class ResourceWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "resource"
     name = "Resource workspace"
     description = "Workspaces containing consortium resources (e.g., examples of using AnVIL, data inventories)"
-    list_table_class_staff_view = DefaultWorkspaceTable
-    list_table_class_view = DefaultWorkspaceTable
+    list_table_class_staff_view = DefaultWorkspaceStaffTable
+    list_table_class_view = DefaultWorkspaceUserTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.ResourceWorkspace
     workspace_data_form_class = forms.ResourceWorkspaceForm
@@ -58,8 +61,8 @@ class TemplateWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "template"
     name = "Template workspace"
     description = "Template workspaces that can be cloned to create other workspaces"
-    list_table_class_staff_view = DefaultWorkspaceTable
-    list_table_class_view = DefaultWorkspaceTable
+    list_table_class_staff_view = DefaultWorkspaceStaffTable
+    list_table_class_view = DefaultWorkspaceUserTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.TemplateWorkspace
     workspace_data_form_class = forms.TemplateWorkspaceForm

--- a/primed/miscellaneous_workspaces/tables.py
+++ b/primed/miscellaneous_workspaces/tables.py
@@ -30,7 +30,7 @@ class OpenAccessWorkspaceStaffTable(tables.Table):
 class OpenAccessWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with OpenAccessWorkspace workspace data."""
 
-    name = tables.columns.Column()
+    name = tables.columns.Column(linkify=True)
     billing_project = tables.Column()
     is_shared = WorkspaceSharedWithConsortiumColumn()
 

--- a/primed/miscellaneous_workspaces/tables.py
+++ b/primed/miscellaneous_workspaces/tables.py
@@ -9,7 +9,7 @@ from primed.primed_anvil.tables import (
 )
 
 
-class OpenAccessWorkspaceTable(tables.Table):
+class OpenAccessWorkspaceStaffTable(tables.Table):
     """Class to render a table of Workspace objects with OpenAccessWorkspace workspace data."""
 
     name = tables.columns.Column(linkify=True)
@@ -27,7 +27,7 @@ class OpenAccessWorkspaceTable(tables.Table):
         order_by = ("name",)
 
 
-class OpenAccessWorkspaceLimitedViewTable(tables.Table):
+class OpenAccessWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with OpenAccessWorkspace workspace data."""
 
     name = tables.columns.Column()

--- a/primed/miscellaneous_workspaces/tests/test_tables.py
+++ b/primed/miscellaneous_workspaces/tests/test_tables.py
@@ -7,11 +7,11 @@ from .. import tables
 from . import factories
 
 
-class OpenAccessWorkspaceTableTest(TestCase):
-    """Tests for the OpenAccessWorkspaceTable table."""
+class OpenAccessWorkspaceStaffTableTest(TestCase):
+    """Tests for the OpenAccessWorkspaceStaffTable table."""
 
     model_factory = factories.OpenAccessWorkspaceFactory
-    table_class = tables.OpenAccessWorkspaceTable
+    table_class = tables.OpenAccessWorkspaceStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(Workspace.objects.all())
@@ -28,11 +28,11 @@ class OpenAccessWorkspaceTableTest(TestCase):
         self.assertEqual(len(table.rows), 2)
 
 
-class OpenAccessWorkspaceLimitedViewTableTest(TestCase):
-    """Tests for the OpenAccessWorkspaceTable table."""
+class OpenAccessWorkspaceUserTableTest(TestCase):
+    """Tests for the OpenAccessWorkspaceStaffTable table."""
 
     model_factory = factories.OpenAccessWorkspaceFactory
-    table_class = tables.OpenAccessWorkspaceLimitedViewTable
+    table_class = tables.OpenAccessWorkspaceUserTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(Workspace.objects.all())

--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -47,30 +47,6 @@ class WorkspaceSharedWithConsortiumColumn(BooleanIconColumn):
         return is_shared
 
 
-# class WorkspaceSharedWithConsortiumTable(tables.Table):
-#     """Table including a column to indicate if a workspace is shared with PRIMED_ALL."""
-
-#     is_shared = tables.columns.Column(
-#         accessor="pk",
-#         verbose_name="Shared with PRIMED?",
-#         orderable=False,
-#     )
-
-#     def render_is_shared(self, record):
-#         is_shared = record.workspacegroupsharing_set.filter(
-#             group__name="PRIMED_ALL"
-#         ).exists()
-#         if is_shared:
-#             icon = "check-circle-fill"
-#             color = "green"
-#             value = format_html(
-#                 """<i class="bi bi-{}" style="color: {};"></i>""".format(icon, color)
-#             )
-#         else:
-#             value = ""
-#         return value
-
-
 class DefaultWorkspaceTable(tables.Table):
     """Class to use for default workspace tables in PRIMED."""
 

--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -47,7 +47,7 @@ class WorkspaceSharedWithConsortiumColumn(BooleanIconColumn):
         return is_shared
 
 
-class DefaultWorkspaceTable(tables.Table):
+class DefaultWorkspaceStaffTable(tables.Table):
     """Class to use for default workspace tables in PRIMED."""
 
     name = tables.Column(linkify=True, verbose_name="Workspace")
@@ -66,6 +66,23 @@ class DefaultWorkspaceTable(tables.Table):
             "name",
             "billing_project",
             "number_groups",
+            "is_shared",
+        )
+        order_by = ("name",)
+
+
+class DefaultWorkspaceUserTable(tables.Table):
+    """Class to use for default workspace tables in PRIMED."""
+
+    name = tables.Column(linkify=True, verbose_name="Workspace")
+    billing_project = tables.Column()
+    is_shared = WorkspaceSharedWithConsortiumColumn()
+
+    class Meta:
+        model = Workspace
+        fields = (
+            "name",
+            "billing_project",
             "is_shared",
         )
         order_by = ("name",)

--- a/primed/primed_anvil/tests/test_views.py
+++ b/primed/primed_anvil/tests/test_views.py
@@ -25,8 +25,8 @@ from primed.dbgap.tests.factories import (
     dbGaPWorkspaceFactory,
 )
 from primed.miscellaneous_workspaces.tables import (
-    OpenAccessWorkspaceLimitedViewTable,
-    OpenAccessWorkspaceTable,
+    OpenAccessWorkspaceStaffTable,
+    OpenAccessWorkspaceUserTable,
 )
 from primed.miscellaneous_workspaces.tests.factories import OpenAccessWorkspaceFactory
 from primed.primed_anvil.tests.factories import AvailableDataFactory, StudyFactory
@@ -260,7 +260,7 @@ class StudyDetailTest(TestCase):
         self.assertIsInstance(response.context_data["tables"][0], dbGaPWorkspaceTable)
         self.assertIsInstance(response.context_data["tables"][1], CDSAWorkspaceTable)
         self.assertIsInstance(
-            response.context_data["tables"][3], OpenAccessWorkspaceTable
+            response.context_data["tables"][3], OpenAccessWorkspaceStaffTable
         )
 
     def test_table_classes_limited_view_permission(self):
@@ -282,7 +282,7 @@ class StudyDetailTest(TestCase):
             response.context_data["tables"][1], CDSAWorkspaceLimitedViewTable
         )
         self.assertIsInstance(
-            response.context_data["tables"][3], OpenAccessWorkspaceLimitedViewTable
+            response.context_data["tables"][3], OpenAccessWorkspaceUserTable
         )
 
     def test_dbgap_workspace_table(self):

--- a/primed/primed_anvil/tests/test_views.py
+++ b/primed/primed_anvil/tests/test_views.py
@@ -12,7 +12,7 @@ from django.shortcuts import resolve_url
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
-from primed.cdsa.tables import CDSAWorkspaceLimitedViewTable, CDSAWorkspaceTable
+from primed.cdsa.tables import CDSAWorkspaceStaffTable, CDSAWorkspaceUserTable
 from primed.cdsa.tests.factories import (
     CDSAWorkspaceFactory,
     DataAffiliateAgreementFactory,
@@ -258,7 +258,9 @@ class StudyDetailTest(TestCase):
         response = self.client.get(self.get_url(obj.pk))
         self.assertIn("tables", response.context_data)
         self.assertIsInstance(response.context_data["tables"][0], dbGaPWorkspaceTable)
-        self.assertIsInstance(response.context_data["tables"][1], CDSAWorkspaceTable)
+        self.assertIsInstance(
+            response.context_data["tables"][1], CDSAWorkspaceStaffTable
+        )
         self.assertIsInstance(
             response.context_data["tables"][3], OpenAccessWorkspaceStaffTable
         )
@@ -279,7 +281,7 @@ class StudyDetailTest(TestCase):
             response.context_data["tables"][0], dbGaPWorkspaceLimitedViewTable
         )
         self.assertIsInstance(
-            response.context_data["tables"][1], CDSAWorkspaceLimitedViewTable
+            response.context_data["tables"][1], CDSAWorkspaceUserTable
         )
         self.assertIsInstance(
             response.context_data["tables"][3], OpenAccessWorkspaceUserTable

--- a/primed/primed_anvil/tests/test_views.py
+++ b/primed/primed_anvil/tests/test_views.py
@@ -18,7 +18,7 @@ from primed.cdsa.tests.factories import (
     DataAffiliateAgreementFactory,
     MemberAgreementFactory,
 )
-from primed.dbgap.tables import dbGaPWorkspaceLimitedViewTable, dbGaPWorkspaceTable
+from primed.dbgap.tables import dbGaPWorkspaceStaffTable, dbGaPWorkspaceUserTable
 from primed.dbgap.tests.factories import (
     dbGaPApplicationFactory,
     dbGaPStudyAccessionFactory,
@@ -257,7 +257,9 @@ class StudyDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(obj.pk))
         self.assertIn("tables", response.context_data)
-        self.assertIsInstance(response.context_data["tables"][0], dbGaPWorkspaceTable)
+        self.assertIsInstance(
+            response.context_data["tables"][0], dbGaPWorkspaceStaffTable
+        )
         self.assertIsInstance(
             response.context_data["tables"][1], CDSAWorkspaceStaffTable
         )
@@ -278,7 +280,7 @@ class StudyDetailTest(TestCase):
         response = self.client.get(self.get_url(obj.pk))
         self.assertIn("tables", response.context_data)
         self.assertIsInstance(
-            response.context_data["tables"][0], dbGaPWorkspaceLimitedViewTable
+            response.context_data["tables"][0], dbGaPWorkspaceUserTable
         )
         self.assertIsInstance(
             response.context_data["tables"][1], CDSAWorkspaceUserTable

--- a/primed/primed_anvil/views.py
+++ b/primed/primed_anvil/views.py
@@ -15,8 +15,8 @@ from django_tables2 import MultiTableMixin, SingleTableMixin, SingleTableView
 
 from primed.cdsa.models import DataAffiliateAgreement, MemberAgreement
 from primed.cdsa.tables import (
-    CDSAWorkspaceLimitedViewTable,
-    CDSAWorkspaceTable,
+    CDSAWorkspaceStaffTable,
+    CDSAWorkspaceUserTable,
     DataAffiliateAgreementTable,
     MemberAgreementTable,
 )
@@ -43,7 +43,7 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
     model = models.Study
     tables = [
         dbGaPWorkspaceTable,
-        CDSAWorkspaceTable,
+        CDSAWorkspaceStaffTable,
         DataAffiliateAgreementTable,
         OpenAccessWorkspaceStaffTable,
     ]
@@ -65,7 +65,7 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
         if self.request.user.has_perm(full_view_perm):
             return (
                 dbGaPWorkspaceTable(dbgap_qs),
-                CDSAWorkspaceTable(cdsa_qs),
+                CDSAWorkspaceStaffTable(cdsa_qs),
                 DataAffiliateAgreementTable(agreement_qs),
                 OpenAccessWorkspaceStaffTable(open_access_qs),
             )
@@ -73,7 +73,7 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
             # Assume they have limited view due to auth mixin.
             return (
                 dbGaPWorkspaceLimitedViewTable(dbgap_qs),
-                CDSAWorkspaceLimitedViewTable(cdsa_qs),
+                CDSAWorkspaceUserTable(cdsa_qs),
                 DataAffiliateAgreementTable(agreement_qs),
                 OpenAccessWorkspaceUserTable(open_access_qs),
             )

--- a/primed/primed_anvil/views.py
+++ b/primed/primed_anvil/views.py
@@ -27,8 +27,8 @@ from primed.dbgap.tables import (
     dbGaPWorkspaceTable,
 )
 from primed.miscellaneous_workspaces.tables import (
-    OpenAccessWorkspaceLimitedViewTable,
-    OpenAccessWorkspaceTable,
+    OpenAccessWorkspaceStaffTable,
+    OpenAccessWorkspaceUserTable,
 )
 from primed.users.tables import UserTable
 
@@ -45,7 +45,7 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
         dbGaPWorkspaceTable,
         CDSAWorkspaceTable,
         DataAffiliateAgreementTable,
-        OpenAccessWorkspaceTable,
+        OpenAccessWorkspaceStaffTable,
     ]
     # table_class = dbGaPWorkspaceTable
     # context_table_name = "dbgap_workspace_table"
@@ -67,7 +67,7 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
                 dbGaPWorkspaceTable(dbgap_qs),
                 CDSAWorkspaceTable(cdsa_qs),
                 DataAffiliateAgreementTable(agreement_qs),
-                OpenAccessWorkspaceTable(open_access_qs),
+                OpenAccessWorkspaceStaffTable(open_access_qs),
             )
         else:
             # Assume they have limited view due to auth mixin.
@@ -75,7 +75,7 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
                 dbGaPWorkspaceLimitedViewTable(dbgap_qs),
                 CDSAWorkspaceLimitedViewTable(cdsa_qs),
                 DataAffiliateAgreementTable(agreement_qs),
-                OpenAccessWorkspaceLimitedViewTable(open_access_qs),
+                OpenAccessWorkspaceUserTable(open_access_qs),
             )
 
 

--- a/primed/primed_anvil/views.py
+++ b/primed/primed_anvil/views.py
@@ -23,8 +23,8 @@ from primed.cdsa.tables import (
 from primed.dbgap.models import dbGaPApplication
 from primed.dbgap.tables import (
     dbGaPApplicationTable,
-    dbGaPWorkspaceLimitedViewTable,
-    dbGaPWorkspaceTable,
+    dbGaPWorkspaceStaffTable,
+    dbGaPWorkspaceUserTable,
 )
 from primed.miscellaneous_workspaces.tables import (
     OpenAccessWorkspaceStaffTable,
@@ -42,12 +42,12 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
 
     model = models.Study
     tables = [
-        dbGaPWorkspaceTable,
+        dbGaPWorkspaceStaffTable,
         CDSAWorkspaceStaffTable,
         DataAffiliateAgreementTable,
         OpenAccessWorkspaceStaffTable,
     ]
-    # table_class = dbGaPWorkspaceTable
+    # table_class = dbGaPWorkspaceStaffTable
     # context_table_name = "dbgap_workspace_table"
 
     def get_tables(self):
@@ -64,7 +64,7 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
         full_view_perm = f"{apm_content_type.app_label}.{AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME}"
         if self.request.user.has_perm(full_view_perm):
             return (
-                dbGaPWorkspaceTable(dbgap_qs),
+                dbGaPWorkspaceStaffTable(dbgap_qs),
                 CDSAWorkspaceStaffTable(cdsa_qs),
                 DataAffiliateAgreementTable(agreement_qs),
                 OpenAccessWorkspaceStaffTable(open_access_qs),
@@ -72,7 +72,7 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
         else:
             # Assume they have limited view due to auth mixin.
             return (
-                dbGaPWorkspaceLimitedViewTable(dbgap_qs),
+                dbGaPWorkspaceUserTable(dbgap_qs),
                 CDSAWorkspaceUserTable(cdsa_qs),
                 DataAffiliateAgreementTable(agreement_qs),
                 OpenAccessWorkspaceUserTable(open_access_qs),
@@ -168,7 +168,7 @@ class AvailableDataDetail(
 
     model = models.AvailableData
     context_table_name = "dbgap_workspace_table"
-    table_class = dbGaPWorkspaceTable
+    table_class = dbGaPWorkspaceStaffTable
     context_table_name = "dbgap_workspace_table"
 
     def get_table_data(self):

--- a/primed/templates/base.html
+++ b/primed/templates/base.html
@@ -118,8 +118,15 @@
           {% endfor %}
       {% endif %}
 
-      {% block content %}
+      {% if not request.user.account %}
+      <div class="alert alert-info" role="alert">
+        <i class="bi bi-exclamation-triangle-fill me-1"></i>
+        You must <a href="{% url 'anvil_consortium_manager:accounts:link' %}">link your AnVIL account</a> before you can access any data on AnVIL.
+      </div>
+      {% endif %}
 
+
+      {% block content %}
               <div class="my-3 alert alert-warning" role="alert">
                 <i class="bi bi-cone-striped"></i>
                 Thanks for visiting!

--- a/primed/templates/duo/datausemodifier_detail.html
+++ b/primed/templates/duo/datausemodifier_detail.html
@@ -3,16 +3,13 @@
 
 {% block title %}DUO modifier {{ object }}{% endblock title %}
 
-{% block after_title %}
-  <a class="btn btn-light" href="{{ object.get_ols_url }}" role="button">
-    <span class="fa-solid fa-arrow-up-right-from-square mx-1"></span>
-    View on OLS
-  </a>
-{% endblock after_title %}
-
 {% block panel %}
   <dl class="row">
-    <dt class="col-sm-2">Identifier</dt> <dd class="col-sm-10">{{ object.identifier }}</dd>
+    <dt class="col-sm-2">Identifier</dt> <dd class="col-sm-10">
+      <a href="{{ object.get_ols_url }}" target="_blank">
+        {{ object.identifier }}<span class="fa-solid fa-arrow-up-right-from-square mx-1"></span>
+      </a>
+    </dd>
     <dt class="col-sm-2">Term</dt> <dd class="col-sm-10">{{ object.term }}</dd>
     <dt class="col-sm-2">Abbreviation</dt> <dd class="col-sm-10">{{ object.abbreviation }}</dd>
     <dt class="col-sm-2">Definition</dt> <dd class="col-sm-10">{{ object.definition }}</dd>

--- a/primed/templates/duo/datausepermission_detail.html
+++ b/primed/templates/duo/datausepermission_detail.html
@@ -3,17 +3,14 @@
 
 {% block title %}DUO permission {{ object }}{% endblock title %}
 
-{% block after_title %}
-  <a class="btn btn-light" href="{{ object.get_ols_url }}" role="button" target="_blank">
-    <span class="fa-solid fa-arrow-up-right-from-square mx-1"></span>
-    View on OLS
-  </a>
-{% endblock after_title %}
-
 {% block panel %}
 <dl class="row">
-  <dt class="col-sm-2">Identifier</dt> <dd class="col-sm-10">{{ object.identifier }}</dd>
-  <dt class="col-sm-2">Term</dt> <dd class="col-sm-10">{{ object.term }}</dd>
+  <dt class="col-sm-2">Identifier</dt> <dd class="col-sm-10">
+    <a href="{{ object.get_ols_url }}" target="_blank">
+      {{ object.identifier }}<span class="fa-solid fa-arrow-up-right-from-square mx-1"></span>
+    </a>
+  </dd>
+<dt class="col-sm-2">Term</dt> <dd class="col-sm-10">{{ object.term }}</dd>
   <dt class="col-sm-2">Abbreviation</dt> <dd class="col-sm-10">{{ object.abbreviation }}</dd>
   <dt class="col-sm-2">Definition</dt> <dd class="col-sm-10">{{ object.definition }}</dd>
   <dt class="col-sm-2">Comment</dt> <dd class="col-sm-10">{{ object.comment }}</dd>

--- a/primed/templates/pages/home.html
+++ b/primed/templates/pages/home.html
@@ -16,10 +16,8 @@
   </header>
 
   <main>
-    <!--
-      <div class="row row-cols-1 row-cols-md-3 mb-3 text-center">
-      -->
-  <div class="row">
+
+    <div class="row">
       <div class="col d-flex align-items-stretch">
         <div class="card mb-4 rounded-3 shadow-sm">
           <div class="card-header py-3">
@@ -48,25 +46,8 @@
         </div>
       </div>
 
-      {% if not request.user.account %}
-      <div class="col d-flex align-items-stretch">
-        <div class="card mb-4 rounded-3 shadow-sm">
-          <div class="card-header py-3">
-            <h4 class="my-0 fw-normal"><i class="fa-solid fa-wand-magic-sparkles pe-2"></i>AnVIL account</h4>
-          </div>
-          <div class="card-body pb-0">
-            <p>
-              If you have not linked your AnVIL account, you must do so before you can access any data on AnVIL.
-            </p>
-          </div>
-          <div class="card-footer bg-transparent border-top-0 text-center pb-3">
-            <a type="button" class="btn btn-secondary" href="{% url 'anvil_consortium_manager:accounts:link' %}">Link your AnVIL account</a>
-          </div>
-        </div>
-      </div>
-      {% endif %}
-
     </div>
+
   </main>
 
 {% endblock content %}

--- a/primed/templates/pages/home.html
+++ b/primed/templates/pages/home.html
@@ -46,6 +46,19 @@
         </div>
       </div>
 
+      <div class="col d-flex align-items-stretch">
+        <div class="card mb-4 rounded-3 shadow-sm">
+          <div class="card-header py-3">
+            <h4 class="my-0 fw-normal"><i class="fa-solid fa-magnifying-glass-chart pe-2"></i> Workspaces</h4>
+          </div>
+          <div class="card-body pb-0">
+            <p>Browse the current set of PRIMED workspaces on AnVIL.</p>
+          </div>
+          <div class="card-footer bg-transparent border-top-0 text-center pb-3">
+            <a type="button" class="btn btn-secondary" href="{% url 'anvil_consortium_manager:workspaces:landing_page' %}">View workspaces</a>
+          </div>
+        </div>
+      </div>
     </div>
 
   </main>

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -32,7 +32,7 @@ django-dbbackup # https://github.com/jazzband/django-dbbackup
 django-extensions  # https://github.com/django-extensions/django-extensions
 
 # anvil_consortium_manager
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.20.1
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.21
 
 # Simple history - model history tracking
 django-simple-history

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -56,7 +56,7 @@ django==4.2.7
     #   django-tables2
 django-allauth==0.54.0
     # via -r requirements/requirements.in
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.20.1
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.21
     # via -r requirements/requirements.in
 django-autocomplete-light==3.9.4
     # via django-anvil-consortium-manager
@@ -93,10 +93,8 @@ fastobo==0.12.2
     # via pronto
 fontawesomefree==6.2.1
     # via django-anvil-consortium-manager
-google-auth[requests]==2.14.1
-    # via
-    #   django-anvil-consortium-manager
-    #   google-auth
+google-auth==2.14.1
+    # via django-anvil-consortium-manager
 idna==3.3
     # via requests
 importlib-metadata==5.2.0
@@ -172,6 +170,7 @@ requests==2.31.0
     # via
     #   -r requirements/requirements.in
     #   django-allauth
+    #   django-anvil-consortium-manager
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via django-allauth


### PR DESCRIPTION
- Update to ACM v0.21. This opens some views up to users with AnVILConsortiumManagerView permission.
- Open DUO views to anyone who with AnVILConsortiumManagerView (so essentially anyone who has logged in)
- Update home page for above changes
- Show an alert to users who have not linked their accounts

Closes #328 