### PR TITLE
Add gitleaksignore file

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,4 @@
+2f8573f44abd55cd30367f673bbbcb4ebc4861bd:test.secrets:generic-api-key:1
+2f8573f44abd55cd30367f673bbbcb4ebc4861bd:test.secrets:generic-api-key:2
+faa490c4de15c23401525ebf6ad532e2bd724e5e:config/settings/base.py:generic-api-key:83
+faa490c4de15c23401525ebf6ad532e2bd724e5e:config/settings/base.py:generic-api-key:84


### PR DESCRIPTION
These fingerprints and secrets in this file are no longer used, but they keep getting detected by periodic gitleaks scans. As a temporary workaround until we can remove them from the repo history, create this file so gitleaks detect stops flagging these every time it runs.