### PR TITLE
Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,5 @@ updates:
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
+    # Allow up to 10 dependencies for pip dependencies
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    allow:
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
 
   # Enable version updates for Python/Pip - Production
   - package-ecosystem: "pip"
@@ -13,4 +14,5 @@ updates:
     directory: "/"
     # Check for updates to GitHub Actions every weekday
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           ANVIL_API_SERVICE_ACCOUNT_FILE: foo
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-data
           path: .coverage.*
@@ -125,7 +125,7 @@ jobs:
           ANVIL_API_SERVICE_ACCOUNT_FILE: foo
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-data
           path: .coverage.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Combine coverage data
         run: |
-          python -m coverage combine
+          python -m coverage combine --data-file=./artifacts/coverage*
           python -m coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,9 @@ jobs:
           pip install --upgrade coverage "django<4" django-coverage-plugin
       - name: Download coverage data
         uses: actions/download-artifact@v4
-        with:
-          name: coverage-data-*
+
+      - name: List downloaded files
+        run: ls -l
 
       - name: Combine coverage data
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,10 @@ jobs:
 
       - name: Combine coverage data
         run: |
+          ls -l ./artifacts/coverage*
           python -m coverage combine --data-file=./artifacts/coverage*
-          ls -la
           ls -R ./artifacts
+          ls -la
           python -m coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,8 @@ jobs:
       - name: Combine coverage data
         run: |
           python -m coverage combine --data-file=./artifacts/coverage*
+          ls -la
+          ls -R ./artifacts
           python -m coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-mysql-${{ strategy.job-index }}
           path: .coverage.*
 
   pytest-sqlite:
@@ -127,7 +127,7 @@ jobs:
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-sqlite-${{ strategy.job-index }}
           path: .coverage.*
 
   coverage:
@@ -151,7 +151,7 @@ jobs:
       - name: Download coverage data
         uses: actions/download-artifact@v3
         with:
-          name: coverage-data
+          name: coverage-data-*
 
       - name: Combine coverage data
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,9 +150,11 @@ jobs:
           pip install --upgrade coverage "django<4" django-coverage-plugin
       - name: Download coverage data
         uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts/
 
       - name: List downloaded files
-        run: ls -R
+        run: ls -R ./artifacts
 
       - name: Combine coverage data
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: List downloaded files
-        run: ls -l
+        run: ls -R
 
       - name: Combine coverage data
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade coverage "django<4" django-coverage-plugin
       - name: Download coverage data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-data-*
 


### PR DESCRIPTION
- Run dependabot weekly
- Allow more than the default number of pull requests
- Run dependabot on both direct and indirect dependencies (may not matter with pip-tools)