### PR TITLE
Dependabot updates, now branched off of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,5 @@ updates:
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
+    # Allow up to 10 dependencies for pip dependencies
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    allow:
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
 
   # Enable version updates for Python/Pip - Production
   - package-ecosystem: "pip"
@@ -13,4 +14,5 @@ updates:
     directory: "/"
     # Check for updates to GitHub Actions every weekday
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
- Run dependabot weekly
- Allow more than the default number of pull requests
- Run dependabot on both direct and indirect dependencies (may not matter with pip-tools)