### PR TITLE
Hide dbGaP audit link from view users

### DIFF
--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -912,6 +912,42 @@ class dbGaPWorkspaceDetailTest(TestCase):
         response = self.client.get(obj.workspace.get_absolute_url())
         self.assertContains(response, obj.get_dbgap_link())
 
+    def test_links_audit_access_staff_view(self):
+        user = UserFactory.create()
+        user.user_permissions.add(
+            Permission.objects.get(
+                codename=AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME
+            )
+        )
+        obj = factories.dbGaPWorkspaceFactory.create()
+        self.client.force_login(user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertContains(
+            response,
+            reverse(
+                "dbgap:workspaces:audit",
+                args=[obj.workspace.billing_project.name, obj.workspace.name],
+            ),
+        )
+
+    def test_links_audit_access_view_permission(self):
+        user = UserFactory.create()
+        user.user_permissions.add(
+            Permission.objects.get(
+                codename=AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            )
+        )
+        obj = factories.dbGaPWorkspaceFactory.create()
+        self.client.force_login(user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertNotContains(
+            response,
+            reverse(
+                "dbgap:workspaces:audit",
+                args=[obj.workspace.billing_project.name, obj.workspace.name],
+            ),
+        )
+
 
 class dbGaPWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
     """Tests of the WorkspaceCreate view from ACM with this app's dbGaPWorkspace model."""

--- a/primed/templates/dbgap/dbgapworkspace_detail.html
+++ b/primed/templates/dbgap/dbgapworkspace_detail.html
@@ -89,9 +89,12 @@
 
 
 {% block action_buttons %}
+
+{% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
 <p>
   <a href="{% url 'dbgap:workspaces:audit' billing_project_slug=object.billing_project.name workspace_slug=object.name%}" class="btn btn-secondary" role="button">Audit application access</a>
 </p>
+{% endif %}
 
 {{block.super}}
 {% endblock action_buttons %}


### PR DESCRIPTION
Regular view users cannot access the dbGaP workspace audit page, so only show that link to staff users.