### PR TITLE
Add view to audit all dbGaP Applications and Workspaces at the same time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,6 +279,7 @@ primed/media/
 
 primed.db
 backup_primed.db
+*.db
 
 ### dbbackups
 dbbackups/

--- a/add_dbgap_example_data.py
+++ b/add_dbgap_example_data.py
@@ -13,7 +13,9 @@ fhs = StudyFactory.create(short_name="FHS", full_name="Framingham Heart Study")
 mesa = StudyFactory.create(
     short_name="MESA", full_name="Multi-Ethnic Study of Atherosclerosis"
 )
-
+aric = StudyFactory.create(
+    short_name="ARIC", full_name="Atherosclerosis Risk in Communities"
+)
 
 # dbGaP study accessions
 dbgap_study_accession_fhs = factories.dbGaPStudyAccessionFactory.create(
@@ -21,6 +23,9 @@ dbgap_study_accession_fhs = factories.dbGaPStudyAccessionFactory.create(
 )
 dbgap_study_accession_mesa = factories.dbGaPStudyAccessionFactory.create(
     dbgap_phs=209, studies=[mesa]
+)
+dbgap_study_accession_aric = factories.dbGaPStudyAccessionFactory.create(
+    dbgap_phs=280, studies=[aric]
 )
 
 
@@ -31,6 +36,7 @@ workspace_fhs_1 = factories.dbGaPWorkspaceFactory.create(
     dbgap_participant_set=12,
     dbgap_consent_code=1,
     dbgap_consent_abbreviation="HMB",
+    workspace__name="DBGAP_FHS_v33_p12_HMB",
 )
 workspace_fhs_2 = factories.dbGaPWorkspaceFactory.create(
     dbgap_study_accession=dbgap_study_accession_fhs,
@@ -38,6 +44,7 @@ workspace_fhs_2 = factories.dbGaPWorkspaceFactory.create(
     dbgap_participant_set=12,
     dbgap_consent_code=2,
     dbgap_consent_abbreviation="GRU",
+    workspace__name="DBGAP_FHS_v33_p12_GRU",
 )
 workspace_mesa_1 = factories.dbGaPWorkspaceFactory.create(
     dbgap_study_accession=dbgap_study_accession_mesa,
@@ -45,6 +52,7 @@ workspace_mesa_1 = factories.dbGaPWorkspaceFactory.create(
     dbgap_participant_set=1,
     dbgap_consent_code=1,
     dbgap_consent_abbreviation="HMB-NPU",
+    workspace__name="DBGAP_MESA_v2_p1_HMB-NPU",
 )
 workspace_mesa_2 = factories.dbGaPWorkspaceFactory.create(
     dbgap_study_accession=dbgap_study_accession_mesa,
@@ -52,6 +60,15 @@ workspace_mesa_2 = factories.dbGaPWorkspaceFactory.create(
     dbgap_participant_set=1,
     dbgap_consent_code=2,
     dbgap_consent_abbreviation="HMB-NPU-IRB",
+    workspace__name="DBGAP_MESA_v2_p1_HMB-NPU-IRB",
+)
+workspace_aric = factories.dbGaPWorkspaceFactory.create(
+    dbgap_study_accession=dbgap_study_accession_aric,
+    dbgap_version=3,
+    dbgap_participant_set=1,
+    dbgap_consent_code=1,
+    dbgap_consent_abbreviation="HMB",
+    workspace__name="DBGAP_ARIC_v3_p1_HMB",
 )
 
 

--- a/add_dbgap_example_data.py
+++ b/add_dbgap_example_data.py
@@ -1,0 +1,119 @@
+# Temporary script to create some test data.
+# Run with: python manage.py shell < add_cdsa_example_data.py
+
+from anvil_consortium_manager.tests.factories import GroupGroupMembershipFactory
+
+from primed.dbgap import models
+from primed.dbgap.tests import factories
+from primed.primed_anvil.tests.factories import StudyFactory
+from primed.users.tests.factories import UserFactory
+
+# Studies
+fhs = StudyFactory.create(short_name="FHS", full_name="Framingham Heart Study")
+mesa = StudyFactory.create(
+    short_name="MESA", full_name="Multi-Ethnic Study of Atherosclerosis"
+)
+
+
+# dbGaP study accessions
+dbgap_study_accession_fhs = factories.dbGaPStudyAccessionFactory.create(
+    dbgap_phs=7, studies=[fhs]
+)
+dbgap_study_accession_mesa = factories.dbGaPStudyAccessionFactory.create(
+    dbgap_phs=209, studies=[mesa]
+)
+
+
+# Create some dbGaP workspaces.
+workspace_fhs_1 = factories.dbGaPWorkspaceFactory.create(
+    dbgap_study_accession=dbgap_study_accession_fhs,
+    dbgap_version=33,
+    dbgap_participant_set=12,
+    dbgap_consent_code=1,
+    dbgap_consent_abbreviation="HMB",
+)
+workspace_fhs_2 = factories.dbGaPWorkspaceFactory.create(
+    dbgap_study_accession=dbgap_study_accession_fhs,
+    dbgap_version=33,
+    dbgap_participant_set=12,
+    dbgap_consent_code=2,
+    dbgap_consent_abbreviation="GRU",
+)
+workspace_mesa_1 = factories.dbGaPWorkspaceFactory.create(
+    dbgap_study_accession=dbgap_study_accession_mesa,
+    dbgap_version=2,
+    dbgap_participant_set=1,
+    dbgap_consent_code=1,
+    dbgap_consent_abbreviation="HMB-NPU",
+)
+workspace_mesa_2 = factories.dbGaPWorkspaceFactory.create(
+    dbgap_study_accession=dbgap_study_accession_mesa,
+    dbgap_version=2,
+    dbgap_participant_set=1,
+    dbgap_consent_code=2,
+    dbgap_consent_abbreviation="HMB-NPU-IRB",
+)
+
+
+# Create some dbGaP applications
+dbgap_application_1 = factories.dbGaPApplicationFactory.create(
+    principal_investigator=UserFactory.create(name="Ken", username="Ken"),
+    dbgap_project_id=33119,
+)
+# Add a snapshot
+dar_snapshot_1 = factories.dbGaPDataAccessSnapshotFactory.create(
+    dbgap_application=dbgap_application_1
+)
+# Add some data access requests.
+dar_1_1 = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
+    dbgap_workspace=workspace_fhs_1,
+    dbgap_data_access_snapshot=dar_snapshot_1,
+    dbgap_dac="NHLBI",
+    dbgap_current_status=models.dbGaPDataAccessRequest.APPROVED,
+)
+dar_1_2 = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
+    dbgap_workspace=workspace_fhs_2,
+    dbgap_data_access_snapshot=dar_snapshot_1,
+    dbgap_dac="NHLBI",
+    dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
+)
+dar_1_3 = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
+    dbgap_workspace=workspace_mesa_1,
+    dbgap_data_access_snapshot=dar_snapshot_1,
+    dbgap_dac="NHLBI",
+    dbgap_current_status=models.dbGaPDataAccessRequest.APPROVED,
+)
+dar_1_4 = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
+    dbgap_workspace=workspace_mesa_2,
+    dbgap_data_access_snapshot=dar_snapshot_1,
+    dbgap_dac="NHLBI",
+    dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
+)
+
+dbgap_application_2 = factories.dbGaPApplicationFactory.create(
+    principal_investigator=UserFactory.create(name="Alisa", username="Alisa"),
+    dbgap_project_id=33371,
+)
+# Add a snapshot
+dar_snapshot_2 = factories.dbGaPDataAccessSnapshotFactory.create(
+    dbgap_application=dbgap_application_2
+)
+# Add some data access requests, only for FHS.
+dar_1_1 = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
+    dbgap_workspace=workspace_fhs_1,
+    dbgap_data_access_snapshot=dar_snapshot_2,
+    dbgap_dac="NHLBI",
+    dbgap_current_status=models.dbGaPDataAccessRequest.APPROVED,
+)
+dar_1_2 = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
+    dbgap_workspace=workspace_fhs_2,
+    dbgap_data_access_snapshot=dar_snapshot_2,
+    dbgap_dac="NHLBI",
+    dbgap_current_status=models.dbGaPDataAccessRequest.APPROVED,
+)
+
+# Now add dbGaP access groups.
+GroupGroupMembershipFactory.create(
+    parent_group=workspace_fhs_1.workspace.authorization_domains.first(),
+    child_group=dbgap_application_1.anvil_access_group,
+)

--- a/primed/collaborative_analysis/tests/factories.py
+++ b/primed/collaborative_analysis/tests/factories.py
@@ -1,0 +1,47 @@
+from anvil_consortium_manager.tests.factories import (
+    ManagedGroupFactory,
+    WorkspaceFactory,
+)
+from factory import LazyAttribute, SubFactory, post_generation
+from factory.django import DjangoModelFactory
+
+from primed.users.tests.factories import UserFactory
+
+from .. import models
+
+
+class CollaborativeAnalysisWorkspaceFactory(DjangoModelFactory):
+    class Meta:
+        model = models.CollaborativeAnalysisWorkspace
+        skip_postgeneration_save = True
+
+    workspace = SubFactory(WorkspaceFactory, workspace_type="collab_analysis")
+    custodian = SubFactory(UserFactory)
+    analyst_group = SubFactory(
+        ManagedGroupFactory,
+        name=LazyAttribute(
+            lambda o: "analysts_{}".format(o.factory_parent.workspace.name)
+        ),
+    )
+
+    @post_generation
+    def authorization_domains(self, create, extracted, **kwargs):
+        # Add an authorization domain.
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        # Create an authorization domain.
+        auth_domain = ManagedGroupFactory.create(
+            name="auth_{}".format(self.workspace.name)
+        )
+        print(auth_domain)
+        self.workspace.authorization_domains.add(auth_domain)
+
+    @post_generation
+    def source_workspaces(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            # Simple build, do nothing.
+            return
+
+        self.source_workspaces.add(*extracted)

--- a/primed/dbgap/audit.py
+++ b/primed/dbgap/audit.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import django_tables2 as tables
+from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
@@ -164,13 +165,26 @@ class dbGaPAccessAudit:
         self.verified = None
         self.needs_action = None
         self.errors = None
+        if dbgap_application_queryset is None:
+            dbgap_application_queryset = dbGaPApplication.objects.all()
+        if not (
+            isinstance(dbgap_application_queryset, QuerySet)
+            and dbgap_application_queryset.model is dbGaPApplication
+        ):
+            raise ValueError(
+                "dbgap_application_queryset must be a queryset of dbGaPApplication objects."
+            )
         self.dbgap_application_queryset = dbgap_application_queryset
+        if dbgap_workspace_queryset is None:
+            dbgap_workspace_queryset = dbGaPWorkspace.objects.all()
+        if not (
+            isinstance(dbgap_workspace_queryset, QuerySet)
+            and dbgap_workspace_queryset.model is dbGaPWorkspace
+        ):
+            raise ValueError(
+                "dbgap_workspace_queryset must be a queryset of dbGaPWorkspace objects."
+            )
         self.dbgap_workspace_queryset = dbgap_workspace_queryset
-        if not self.dbgap_application_queryset:
-            self.dbgap_application_queryset = dbGaPApplication.objects.all()
-        if not self.dbgap_workspace_queryset:
-            self.dbgap_workspace_queryset = dbGaPWorkspace.objects.all()
-        # Check types of workspaces.
 
     def run_audit(self):
         self.verified = []

--- a/primed/dbgap/audit.py
+++ b/primed/dbgap/audit.py
@@ -6,6 +6,8 @@ from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 # from . import models
+from primed.primed_anvil.tables import BooleanIconColumn
+
 from .models import (
     dbGaPApplication,
     dbGaPDataAccessRequest,
@@ -22,6 +24,7 @@ class AuditResult:
     workspace: dbGaPWorkspace
     note: str
     dbgap_application: dbGaPApplication
+    has_access: bool
     data_access_request: dbGaPDataAccessRequest = None
 
     def __post_init__(self):
@@ -55,6 +58,7 @@ class AuditResult:
             "data_access_request": self.data_access_request,
             "dar_accession": dar_accession,
             "dar_consent": dar_consent,
+            "has_access": self.has_access,
             "note": self.note,
             "action": self.get_action(),
             "action_url": self.get_action_url(),
@@ -66,19 +70,21 @@ class AuditResult:
 class VerifiedAccess(AuditResult):
     """Audit results class for when access has been verified."""
 
-    pass
+    has_access: bool = True
 
 
 @dataclass
 class VerifiedNoAccess(AuditResult):
     """Audit results class for when no access has been verified."""
 
-    pass
+    has_access: bool = False
 
 
 @dataclass
 class GrantAccess(AuditResult):
     """Audit results class for when access should be granted."""
+
+    has_access: bool = False
 
     def get_action(self):
         return "Grant access"
@@ -96,6 +102,8 @@ class GrantAccess(AuditResult):
 @dataclass
 class RemoveAccess(AuditResult):
     """Audit results class for when access should be removed for a known reason."""
+
+    has_access: bool = True
 
     def get_action(self):
         return "Remove access"
@@ -125,6 +133,7 @@ class dbGaPAccessAuditTable(tables.Table):
     data_access_request = tables.Column()
     dar_accession = tables.Column(verbose_name="DAR accession")
     dar_consent = tables.Column(verbose_name="DAR consent")
+    has_access = BooleanIconColumn(show_false_icon=True)
     note = tables.Column()
     action = tables.Column()
 

--- a/primed/dbgap/tests/factories.py
+++ b/primed/dbgap/tests/factories.py
@@ -166,7 +166,9 @@ class dbGaPDataAccessRequestForWorkspaceFactory(DjangoModelFactory):
         lambda o: o.dbgap_workspace.dbgap_participant_set
     )
     dbgap_consent_code = LazyAttribute(lambda o: o.dbgap_workspace.dbgap_consent_code)
-    dbgap_consent_abbreviation = Faker("word")
+    dbgap_consent_abbreviation = LazyAttribute(
+        lambda o: o.dbgap_workspace.dbgap_consent_abbreviation
+    )
     dbgap_current_status = models.dbGaPDataAccessRequest.APPROVED
     dbgap_dac = Faker("word")
 

--- a/primed/dbgap/tests/factories.py
+++ b/primed/dbgap/tests/factories.py
@@ -91,7 +91,9 @@ class dbGaPWorkspaceFactory(TimeStampedModelFactory, DjangoModelFactory):
             return
 
         # Create an authorization domain.
-        auth_domain = ManagedGroupFactory.create()
+        auth_domain = ManagedGroupFactory.create(
+            name="auth_{}".format(self.workspace.name)
+        )
         self.workspace.authorization_domains.add(auth_domain)
 
 

--- a/primed/dbgap/tests/factories.py
+++ b/primed/dbgap/tests/factories.py
@@ -2,6 +2,7 @@ from anvil_consortium_manager.tests.factories import (
     ManagedGroupFactory,
     WorkspaceFactory,
 )
+from django.conf import settings
 from factory import (
     Dict,
     DictFactory,
@@ -99,7 +100,15 @@ class dbGaPApplicationFactory(DjangoModelFactory):
 
     principal_investigator = SubFactory(UserFactory)
     dbgap_project_id = Sequence(lambda n: n + 1)
-    anvil_access_group = SubFactory(ManagedGroupFactory)
+    anvil_access_group = SubFactory(
+        ManagedGroupFactory,
+        name=LazyAttribute(
+            lambda o: "{}_DBGAP_ACCESS_{}".format(
+                settings.ANVIL_DATA_ACCESS_GROUP_PREFIX,
+                o.factory_parent.dbgap_project_id,
+            )
+        ),
+    )
 
     class Meta:
         model = models.dbGaPApplication

--- a/primed/dbgap/tests/test_audit.py
+++ b/primed/dbgap/tests/test_audit.py
@@ -119,22 +119,30 @@ class AuditResultTest(TestCase):
             )
 
 
-class dbGaPApplicationAccessAuditTest(TestCase):
-    """Tests for the dbGaPApplicationAccessAudit class."""
+class dbGaPAccessAuditTest(TestCase):
+    """Tests for the dbGaPAccessAudit class."""
 
     def test_completed(self):
         """completed is updated properly."""
-        dbgap_application = factories.dbGaPApplicationFactory.create()
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(dbgap_application)
+        dbgap_audit = audit.dbGaPAccessAudit()
         self.assertFalse(dbgap_audit.completed)
         dbgap_audit.run_audit()
         self.assertTrue(dbgap_audit.completed)
 
-    def test_no_workspaces_no_snapshots(self):
-        """run_audit with no existing workspaces and no snapshots."""
+    def test_one_application_no_workspace(self):
+        """run_audit with one application and no existing workspaces."""
+        factories.dbGaPApplicationFactory.create()
+        dbgap_audit = audit.dbGaPAccessAudit()
+        dbgap_audit.run_audit()
+        self.assertEqual(len(dbgap_audit.verified), 0)
+        self.assertEqual(len(dbgap_audit.needs_action), 0)
+        self.assertEqual(len(dbgap_audit.errors), 0)
+
+    def test_one_application_one_workspace_no_snapshots(self):
+        """run_audit with one application, one workspaces and no snapshots."""
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
         dbgap_application = factories.dbGaPApplicationFactory.create()
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(dbgap_application)
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 1)
         self.assertEqual(len(dbgap_audit.needs_action), 0)
@@ -146,23 +154,12 @@ class dbGaPApplicationAccessAuditTest(TestCase):
         self.assertIsNone(record.data_access_request)
         self.assertEqual(record.note, audit.dbGaPAccessAudit.NO_SNAPSHOTS)
 
-    def test_one_workspaces_no_snapshots(self):
-        """run_audit with no existing workspaces and no snapshots."""
-        dbgap_application = factories.dbGaPApplicationFactory.create()
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(dbgap_application)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-
-    def test_snapshot_has_no_dars(self):
+    def test_one_application_one_workspace_snapshot_has_no_dars(self):
         """run_audit with no dars."""
         # Create a workspace and a snapshot.
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
         dbgap_snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dbgap_snapshot.dbgap_application
-        )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 1)
         self.assertEqual(len(dbgap_audit.needs_action), 0)
@@ -174,8 +171,8 @@ class dbGaPApplicationAccessAuditTest(TestCase):
         self.assertIsNone(record.data_access_request)
         self.assertEqual(record.note, audit.dbGaPAccessAudit.NO_DAR)
 
-    def test_one_verified_access(self):
-        """run_audit with one workspace that has verified access."""
+    def test_verified_access(self):
+        """run_audit with one application and one workspace that has verified access."""
         # Create a workspace and matching DAR.
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
         dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
@@ -186,9 +183,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             parent_group=dbgap_workspace.workspace.authorization_domains.first(),
             child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
         )
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dar.dbgap_data_access_snapshot.dbgap_application
-        )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 1)
         self.assertEqual(len(dbgap_audit.needs_action), 0)
@@ -201,8 +196,8 @@ class dbGaPApplicationAccessAuditTest(TestCase):
         )
         self.assertEqual(record.data_access_request, dar)
 
-    def test_two_verified_access(self):
-        """run_audit with two workspaces that have verified access."""
+    def test_two_workspaces(self):
+        """run_audit with one application and two workspaces with different access."""
         dbgap_snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
         # Create two workspaces and matching DARs.
         dbgap_workspace_1 = factories.dbGaPWorkspaceFactory.create()
@@ -213,35 +208,33 @@ class dbGaPApplicationAccessAuditTest(TestCase):
         dar_2 = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
             dbgap_workspace=dbgap_workspace_2, dbgap_data_access_snapshot=dbgap_snapshot
         )
-        # Add the anvil group to the auth groups for the workspaces.
+        # Add the anvil group to the auth groups for the first workspace.
         GroupGroupMembershipFactory(
             parent_group=dbgap_workspace_1.workspace.authorization_domains.first(),
             child_group=dar_1.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
         )
-        GroupGroupMembershipFactory(
-            parent_group=dbgap_workspace_2.workspace.authorization_domains.first(),
-            child_group=dar_2.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
-        )
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dbgap_snapshot.dbgap_application
-        )
+        # GroupGroupMembershipFactory(
+        #     parent_group=dbgap_workspace_2.workspace.authorization_domains.first(),
+        #     child_group=dar_2.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
+        # )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 2)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
+        self.assertEqual(len(dbgap_audit.verified), 1)
+        self.assertEqual(len(dbgap_audit.needs_action), 1)
         self.assertEqual(len(dbgap_audit.errors), 0)
         record = dbgap_audit.verified[0]
         self.assertIsInstance(record, audit.VerifiedAccess)
         self.assertEqual(record.workspace, dbgap_workspace_1)
         self.assertEqual(record.data_access_request, dar_1)
         self.assertEqual(record.dbgap_application, dbgap_snapshot.dbgap_application)
-        record = dbgap_audit.verified[1]
-        self.assertIsInstance(record, audit.VerifiedAccess)
+        record = dbgap_audit.needs_action[0]
+        self.assertIsInstance(record, audit.GrantAccess)
         self.assertEqual(record.workspace, dbgap_workspace_2)
         self.assertEqual(record.dbgap_application, dbgap_snapshot.dbgap_application)
         self.assertEqual(record.data_access_request, dar_2)
 
-    def test_one_verified_no_access_dar_not_approved(self):
-        """run_audit with one workspace that has verified no access."""
+    def test_verified_no_access_dar_not_approved(self):
+        """run_audit with one application and one workspace that has verified no access."""
         # Create a workspace and matching DAR.
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
         dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
@@ -249,9 +242,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
         )
         # Do not add the anvil group to the auth group for the workspace.
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dar.dbgap_data_access_snapshot.dbgap_application
-        )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 1)
         self.assertEqual(len(dbgap_audit.needs_action), 0)
@@ -263,9 +254,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
         )
         self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.DAR_NOT_APPROVED
-        )
+        self.assertEqual(record.note, audit.dbGaPAccessAudit.DAR_NOT_APPROVED)
 
     def test_grant_access_new_approved_dar(self):
         # Create a workspace and matching DAR.
@@ -278,9 +267,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=2),
         )
         # Do not add the anvil group to the auth group for the workspace.
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dar.dbgap_data_access_snapshot.dbgap_application
-        )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 0)
         self.assertEqual(len(dbgap_audit.needs_action), 1)
@@ -292,9 +279,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
         )
         self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.NEW_APPROVED_DAR
-        )
+        self.assertEqual(record.note, audit.dbGaPAccessAudit.NEW_APPROVED_DAR)
 
     def test_grant_access_new_workspace(self):
         # Create a workspace and matching DAR.
@@ -307,9 +292,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=3),
         )
         # Do not add the anvil group to the auth group for the workspace.
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dar.dbgap_data_access_snapshot.dbgap_application
-        )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 0)
         self.assertEqual(len(dbgap_audit.needs_action), 1)
@@ -321,7 +304,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
         )
         self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(record.note, audit.dbGaPApplicationAccessAudit.NEW_WORKSPACE)
+        self.assertEqual(record.note, audit.dbGaPAccessAudit.NEW_WORKSPACE)
 
     def test_grant_access_updated_dar(self):
         # Create a workspace and matching DAR.
@@ -345,9 +328,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=2),
         )
         # Do not add the anvil group to the auth group for the workspace.
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dar.dbgap_data_access_snapshot.dbgap_application
-        )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 0)
         self.assertEqual(len(dbgap_audit.needs_action), 1)
@@ -359,9 +340,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
         )
         self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.NEW_APPROVED_DAR
-        )
+        self.assertEqual(record.note, audit.dbGaPAccessAudit.NEW_APPROVED_DAR)
 
     def test_remove_access_udpated_dar(self):
         # Create a workspace and matching DAR.
@@ -387,9 +366,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             parent_group=dbgap_workspace.workspace.authorization_domains.first(),
             child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
         )
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dar.dbgap_data_access_snapshot.dbgap_application
-        )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 0)
         self.assertEqual(len(dbgap_audit.needs_action), 1)
@@ -401,34 +378,35 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
         )
         self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.PREVIOUS_APPROVAL
-        )
+        self.assertEqual(record.note, audit.dbGaPAccessAudit.PREVIOUS_APPROVAL)
 
     def test_error_remove_access_unknown_reason(self):
         """Access needs to be removed for an unknown reason."""
+        dbgap_application = factories.dbGaPApplicationFactory.create()
         # Create a workspace and matching DAR.
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
         # Create an old snapshot where the DAR was rejected and a new one where it is still rejected.
         old_dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
             dbgap_workspace=dbgap_workspace,
+            dbgap_data_access_snapshot__dbgap_application=dbgap_application,
             dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=3),
+            dbgap_data_access_snapshot__is_most_recent=False,
             dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
         )
         dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
             dbgap_dar_id=old_dar.dbgap_dar_id,
             dbgap_workspace=dbgap_workspace,
+            dbgap_data_access_snapshot__dbgap_application=dbgap_application,
             dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=2),
+            dbgap_data_access_snapshot__is_most_recent=True,
             dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
         )
         # Add the anvil group to the auth group for the workspace.
         GroupGroupMembershipFactory.create(
             parent_group=dbgap_workspace.workspace.authorization_domains.first(),
-            child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
+            child_group=dbgap_application.anvil_access_group,
         )
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dar.dbgap_data_access_snapshot.dbgap_application
-        )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 0)
         self.assertEqual(len(dbgap_audit.needs_action), 0)
@@ -436,13 +414,9 @@ class dbGaPApplicationAccessAuditTest(TestCase):
         record = dbgap_audit.errors[0]
         self.assertIsInstance(record, audit.RemoveAccess)
         self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
+        self.assertEqual(record.dbgap_application, dbgap_application)
         self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.ERROR_HAS_ACCESS
-        )
+        self.assertEqual(record.note, audit.dbGaPAccessAudit.ERROR_HAS_ACCESS)
 
     def test_error_remove_access_no_snapshot(self):
         """Access needs to be removed for an unknown reason when there is no snapshot."""
@@ -454,7 +428,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             parent_group=dbgap_workspace.workspace.authorization_domains.first(),
             child_group=dbgap_application.anvil_access_group,
         )
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(dbgap_application)
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 0)
         self.assertEqual(len(dbgap_audit.needs_action), 0)
@@ -464,9 +438,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
         self.assertEqual(record.workspace, dbgap_workspace)
         self.assertEqual(record.dbgap_application, dbgap_application)
         self.assertIsNone(record.data_access_request)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.ERROR_HAS_ACCESS
-        )
+        self.assertEqual(record.note, audit.dbGaPAccessAudit.ERROR_HAS_ACCESS)
 
     def test_error_remove_access_snapshot_no_dar(self):
         """Group has access but there is no matching DAR."""
@@ -478,7 +450,7 @@ class dbGaPApplicationAccessAuditTest(TestCase):
             parent_group=dbgap_workspace.workspace.authorization_domains.first(),
             child_group=snapshot.dbgap_application.anvil_access_group,
         )
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(snapshot.dbgap_application)
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
         self.assertEqual(len(dbgap_audit.verified), 0)
         self.assertEqual(len(dbgap_audit.needs_action), 0)
@@ -488,121 +460,10 @@ class dbGaPApplicationAccessAuditTest(TestCase):
         self.assertEqual(record.workspace, dbgap_workspace)
         self.assertEqual(record.dbgap_application, snapshot.dbgap_application)
         self.assertIsNone(record.data_access_request)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.ERROR_HAS_ACCESS
-        )
+        self.assertEqual(record.note, audit.dbGaPAccessAudit.ERROR_HAS_ACCESS)
 
-    def test_approved_dar_for_different_application(self):
-        """There is an approved dar for a different application, but not this one."""
-        # Create a workspace and matching DAR.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        # Create an approved DAR from an unrelated application.
-        factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace
-        )
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
-        )
-        dbgap_audit = audit.dbGaPApplicationAccessAudit(
-            dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 1)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.verified[0]
-        self.assertIsInstance(record, audit.VerifiedNoAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.DAR_NOT_APPROVED
-        )
-
-
-class dbGaPWorkspaceAccessAuditTest(TestCase):
-    """Tests for the dbGaPWorkspaceAccessAudit class."""
-
-    def test_completed(self):
-        """completed is updated properly."""
-        workspace = factories.dbGaPWorkspaceFactory.create()
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(workspace)
-        self.assertFalse(dbgap_audit.completed)
-        dbgap_audit.run_audit()
-        self.assertTrue(dbgap_audit.completed)
-
-    def test_no_applications_no_snapshots(self):
-        """run_audit with no existing workspaces and no snapshots."""
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-
-    def test_one_application_no_snapshots(self):
-        """run_audit with no existing workspaces and no snapshots."""
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        dbgap_application = factories.dbGaPApplicationFactory.create()
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 1)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.verified[0]
-        self.assertIsInstance(record, audit.VerifiedNoAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dbgap_application)
-        self.assertIsNone(record.data_access_request)
-        self.assertEqual(record.note, audit.dbGaPAccessAudit.NO_SNAPSHOTS)
-
-    def test_snapshot_has_no_dars(self):
-        """run_audit with one snapshot that has no dars."""
-        # Create a workspace and a snapshot.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        dbgap_snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 1)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.verified[0]
-        self.assertIsInstance(record, audit.VerifiedNoAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dbgap_snapshot.dbgap_application)
-        self.assertIsNone(record.data_access_request)
-        self.assertEqual(record.note, audit.dbGaPAccessAudit.NO_DAR)
-
-    def test_one_verified_access(self):
-        """run_audit with one workspace that has verified access."""
-        # Create a workspace and matching DAR.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace
-        )
-        # Add the anvil group to the auth group for the workspace.
-        GroupGroupMembershipFactory(
-            parent_group=dbgap_workspace.workspace.authorization_domains.first(),
-            child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
-        )
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 1)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.verified[0]
-        self.assertIsInstance(record, audit.VerifiedAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        self.assertEqual(record.data_access_request, dar)
-
-    def test_two_verified_access(self):
-        """run_audit with two applications that have verified access."""
+    def test_two_applications(self):
+        """run_audit with two applications and one workspace."""
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
         # Create two applications and matching DARs.
         dbgap_snapshot_1 = factories.dbGaPDataAccessSnapshotFactory.create()
@@ -613,19 +474,19 @@ class dbGaPWorkspaceAccessAuditTest(TestCase):
         dar_2 = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
             dbgap_workspace=dbgap_workspace, dbgap_data_access_snapshot=dbgap_snapshot_2
         )
-        # Add the anvil group to the auth groups for the workspaces.
+        # Add the anvil group for the first applicatoin to the auth groups for the workspace.
         GroupGroupMembershipFactory(
             parent_group=dbgap_workspace.workspace.authorization_domains.first(),
             child_group=dbgap_snapshot_1.dbgap_application.anvil_access_group,
         )
-        GroupGroupMembershipFactory(
-            parent_group=dbgap_workspace.workspace.authorization_domains.first(),
-            child_group=dbgap_snapshot_2.dbgap_application.anvil_access_group,
-        )
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
+        # GroupGroupMembershipFactory(
+        #     parent_group=dbgap_workspace.workspace.authorization_domains.first(),
+        #     child_group=dbgap_snapshot_2.dbgap_application.anvil_access_group,
+        # )
+        dbgap_audit = audit.dbGaPAccessAudit()
         dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 2)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
+        self.assertEqual(len(dbgap_audit.verified), 1)
+        self.assertEqual(len(dbgap_audit.needs_action), 1)
         self.assertEqual(len(dbgap_audit.errors), 0)
         record = dbgap_audit.verified[0]
         self.assertIsInstance(record, audit.VerifiedAccess)
@@ -634,291 +495,13 @@ class dbGaPWorkspaceAccessAuditTest(TestCase):
             record.dbgap_application, dar_1.dbgap_data_access_snapshot.dbgap_application
         )
         self.assertEqual(record.data_access_request, dar_1)
-        record = dbgap_audit.verified[1]
-        self.assertIsInstance(record, audit.VerifiedAccess)
+        record = dbgap_audit.needs_action[0]
+        self.assertIsInstance(record, audit.GrantAccess)
         self.assertEqual(record.workspace, dbgap_workspace)
         self.assertEqual(
             record.dbgap_application, dar_2.dbgap_data_access_snapshot.dbgap_application
         )
         self.assertEqual(record.data_access_request, dar_2)
-
-    def test_one_verified_no_access_dar_not_approved(self):
-        """run_audit with one application that has verified no access."""
-        # Create a workspace and matching DAR.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
-        )
-        # Do not add the anvil group to the auth group for the workspace.
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 1)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.verified[0]
-        self.assertIsInstance(record, audit.VerifiedNoAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.DAR_NOT_APPROVED
-        )
-
-    def test_grant_access_new_approved_dar(self):
-        # Create a workspace and matching DAR.
-        # Workspace was created before the snapshot.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(
-            created=timezone.now() - timedelta(weeks=3)
-        )
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=2),
-        )
-        # Do not add the anvil group to the auth group for the workspace.
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 1)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.needs_action[0]
-        self.assertIsInstance(record, audit.GrantAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.NEW_APPROVED_DAR
-        )
-
-    def test_grant_access_new_workspace(self):
-        # Create a workspace and matching DAR.
-        # Workspace was created after the snapshot.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(
-            created=timezone.now() - timedelta(weeks=2)
-        )
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=3),
-        )
-        # Do not add the anvil group to the auth group for the workspace.
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 1)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.needs_action[0]
-        self.assertIsInstance(record, audit.GrantAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(record.note, audit.dbGaPApplicationAccessAudit.NEW_WORKSPACE)
-
-    def test_grant_access_updated_dar(self):
-        # Create a workspace and matching DAR.
-        # Workspace was created before the snapshot.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(
-            created=timezone.now() - timedelta(weeks=4)
-        )
-        dbgap_application = factories.dbGaPApplicationFactory.create()
-        # Create an old snapshot where the DAR was not approved.
-        old_dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__is_most_recent=False,
-            dbgap_data_access_snapshot__dbgap_application=dbgap_application,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=3),
-            dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
-        )
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_dar_id=old_dar.dbgap_dar_id,
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__dbgap_application=dbgap_application,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=2),
-        )
-        # Do not add the anvil group to the auth group for the workspace.
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 1)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.needs_action[0]
-        self.assertIsInstance(record, audit.GrantAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.NEW_APPROVED_DAR
-        )
-
-    def test_remove_access_udpated_dar(self):
-        # Create a workspace and matching DAR.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        dbgap_application = factories.dbGaPApplicationFactory.create()
-        # Create an old snapshot where the DAR was approved and a new one where it was closed.
-        old_dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__dbgap_application=dbgap_application,
-            dbgap_data_access_snapshot__is_most_recent=False,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=3),
-            dbgap_current_status=models.dbGaPDataAccessRequest.APPROVED,
-        )
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_dar_id=old_dar.dbgap_dar_id,
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__dbgap_application=dbgap_application,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=2),
-            dbgap_current_status=models.dbGaPDataAccessRequest.CLOSED,
-        )
-        # Add the anvil group to the auth group for the workspace.
-        GroupGroupMembershipFactory.create(
-            parent_group=dbgap_workspace.workspace.authorization_domains.first(),
-            child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
-        )
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 1)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.needs_action[0]
-        self.assertIsInstance(record, audit.RemoveAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.PREVIOUS_APPROVAL
-        )
-
-    def test_error_remove_access_unknown_reason(self):
-        """Access needs to be removed for an unknown reason."""
-        # Create a workspace and matching DAR.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        dbgap_application = factories.dbGaPApplicationFactory.create()
-        # Create an old snapshot where the DAR was rejected and a new one where it is still rejected.
-        old_dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__dbgap_application=dbgap_application,
-            dbgap_data_access_snapshot__is_most_recent=False,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=3),
-            dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
-        )
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_dar_id=old_dar.dbgap_dar_id,
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__dbgap_application=dbgap_application,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=2),
-            dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
-        )
-        # Add the anvil group to the auth group for the workspace.
-        GroupGroupMembershipFactory.create(
-            parent_group=dbgap_workspace.workspace.authorization_domains.first(),
-            child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
-        )
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 1)
-        record = dbgap_audit.errors[0]
-        self.assertIsInstance(record, audit.RemoveAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.ERROR_HAS_ACCESS
-        )
-
-    def test_error_remove_access_no_snapshot(self):
-        """Access needs to be removed for an unknown reason when there is no snapshot."""
-        # Create a workspace and matching DAR.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        dbgap_application = factories.dbGaPApplicationFactory.create()
-        # Add the anvil group to the auth group for the workspace.
-        GroupGroupMembershipFactory.create(
-            parent_group=dbgap_workspace.workspace.authorization_domains.first(),
-            child_group=dbgap_application.anvil_access_group,
-        )
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 1)
-        record = dbgap_audit.errors[0]
-        self.assertIsInstance(record, audit.RemoveAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dbgap_application)
-        self.assertIsNone(record.data_access_request)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.ERROR_HAS_ACCESS
-        )
-
-    def test_error_remove_access_snapshot_no_dar(self):
-        """Group has access but there is no matching DAR."""
-        # Create a workspace but no matching DAR.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        # Add the anvil group to the auth group for the workspace.
-        snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
-        GroupGroupMembershipFactory.create(
-            parent_group=dbgap_workspace.workspace.authorization_domains.first(),
-            child_group=snapshot.dbgap_application.anvil_access_group,
-        )
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 1)
-        record = dbgap_audit.errors[0]
-        self.assertIsInstance(record, audit.RemoveAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, snapshot.dbgap_application)
-        self.assertEqual(record.data_access_request, None)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.ERROR_HAS_ACCESS
-        )
-
-    def test_approved_dar_for_different_workspace(self):
-        """There is an approved dar for a different workspace, but not this one."""
-        # Create a workspace and matching DAR.
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        # Create an unrelated workspace.
-        other_dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
-        dbgap_snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
-        # Create an approved DAR for the other workspace.
-        factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=other_dbgap_workspace,
-            dbgap_data_access_snapshot=dbgap_snapshot,
-        )
-        # Create a rejected DAR for this workspace.
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_data_access_snapshot=dbgap_snapshot,
-            dbgap_workspace=dbgap_workspace,
-            dbgap_current_status=models.dbGaPDataAccessRequest.REJECTED,
-        )
-        dbgap_audit = audit.dbGaPWorkspaceAccessAudit(dbgap_workspace)
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 1)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.verified[0]
-        self.assertIsInstance(record, audit.VerifiedNoAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(
-            record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application
-        )
-        self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(
-            record.note, audit.dbGaPApplicationAccessAudit.DAR_NOT_APPROVED
-        )
 
 
 class dbGaPAccessAuditTableTest(TestCase):

--- a/primed/dbgap/tests/test_audit.py
+++ b/primed/dbgap/tests/test_audit.py
@@ -503,6 +503,78 @@ class dbGaPAccessAuditTest(TestCase):
         )
         self.assertEqual(record.data_access_request, dar_2)
 
+    def test_dbgap_application_queryset(self):
+        """dbGapAccessAudit only includes the specified dbgap_application_queryset objects."""
+        dbgap_application_1 = factories.dbGaPApplicationFactory.create()
+        dbgap_application_2 = factories.dbGaPApplicationFactory.create()
+        dbgap_application_3 = factories.dbGaPApplicationFactory.create()
+        dbgap_audit = audit.dbGaPAccessAudit(
+            dbgap_application_queryset=models.dbGaPApplication.objects.filter(
+                pk__in=[dbgap_application_1.pk, dbgap_application_2.pk]
+            )
+        )
+        self.assertEqual(dbgap_audit.dbgap_application_queryset.count(), 2)
+        self.assertIn(dbgap_application_1, dbgap_audit.dbgap_application_queryset)
+        self.assertIn(dbgap_application_2, dbgap_audit.dbgap_application_queryset)
+        self.assertNotIn(dbgap_application_3, dbgap_audit.dbgap_application_queryset)
+
+    def test_dbgap_workspace_queryset(self):
+        """dbGapAccessAudit only includes the specified dbgap_application_queryset objects."""
+        dbgap_workspace_1 = factories.dbGaPWorkspaceFactory.create()
+        dbgap_workspace_2 = factories.dbGaPWorkspaceFactory.create()
+        dbgap_workspace_3 = factories.dbGaPWorkspaceFactory.create()
+        dbgap_audit = audit.dbGaPAccessAudit(
+            dbgap_workspace_queryset=models.dbGaPWorkspace.objects.filter(
+                pk__in=[dbgap_workspace_1.pk, dbgap_workspace_2.pk]
+            )
+        )
+        self.assertEqual(dbgap_audit.dbgap_workspace_queryset.count(), 2)
+        self.assertIn(dbgap_workspace_1, dbgap_audit.dbgap_workspace_queryset)
+        self.assertIn(dbgap_workspace_2, dbgap_audit.dbgap_workspace_queryset)
+        self.assertNotIn(dbgap_workspace_3, dbgap_audit.dbgap_workspace_queryset)
+
+    def test_dbgap_workspace_queryset_wrong_class(self):
+        """dbGaPAccessAudit raises error if dbgap_workspace_queryset has the wrong model class."""
+        with self.assertRaises(ValueError) as e:
+            audit.dbGaPAccessAudit(
+                dbgap_workspace_queryset=models.dbGaPApplication.objects.all()
+            )
+        self.assertEqual(
+            str(e.exception),
+            "dbgap_workspace_queryset must be a queryset of dbGaPWorkspace objects.",
+        )
+
+    def test_dbgap_workspace_queryset_not_queryset(self):
+        """dbGaPAccessAudit raises error if dbgap_workspace_queryset is not a queryset."""
+        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
+        with self.assertRaises(ValueError) as e:
+            audit.dbGaPAccessAudit(dbgap_workspace_queryset=dbgap_workspace)
+        self.assertEqual(
+            str(e.exception),
+            "dbgap_workspace_queryset must be a queryset of dbGaPWorkspace objects.",
+        )
+
+    def test_dbgap_application_queryset_wrong_class(self):
+        """dbGaPAccessAudit raises error if dbgap_application_queryset has the wrong model class."""
+        with self.assertRaises(ValueError) as e:
+            audit.dbGaPAccessAudit(
+                dbgap_application_queryset=models.dbGaPWorkspace.objects.all()
+            )
+        self.assertEqual(
+            str(e.exception),
+            "dbgap_application_queryset must be a queryset of dbGaPApplication objects.",
+        )
+
+    def test_dbgap_application_queryset_not_queryset(self):
+        """dbGaPAccessAudit raises error if dbgap_application_queryset is not a queryset."""
+        dbgap_application = factories.dbGaPApplicationFactory.create()
+        with self.assertRaises(ValueError) as e:
+            audit.dbGaPAccessAudit(dbgap_application_queryset=dbgap_application)
+        self.assertEqual(
+            str(e.exception),
+            "dbgap_application_queryset must be a queryset of dbGaPApplication objects.",
+        )
+
 
 class dbGaPAccessAuditTableTest(TestCase):
     """Tests for the `dbGaPAccessAuditTableTest` table."""

--- a/primed/dbgap/tests/test_audit.py
+++ b/primed/dbgap/tests/test_audit.py
@@ -22,6 +22,7 @@ class AuditResultTest(TestCase):
             note="foo",
         )
         self.assertIsNone(instance.get_action_url())
+        self.assertTrue(instance.has_access)
 
     def test_verified_no_access(self):
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
@@ -33,6 +34,7 @@ class AuditResultTest(TestCase):
             note="foo",
         )
         self.assertIsNone(instance.get_action_url())
+        self.assertFalse(instance.has_access)
 
     def test_grant_access(self):
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
@@ -52,6 +54,7 @@ class AuditResultTest(TestCase):
             ],
         )
         self.assertEqual(instance.get_action_url(), expected_url)
+        self.assertFalse(instance.has_access)
 
     def test_remove_access(self):
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
@@ -71,12 +74,15 @@ class AuditResultTest(TestCase):
             ],
         )
         self.assertEqual(instance.get_action_url(), expected_url)
+        self.assertTrue(instance.has_access)
 
     def test_remove_access_no_dar(self):
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
         dbgap_application = factories.dbGaPApplicationFactory.create()
         instance = audit.RemoveAccess(
-            workspace=dbgap_workspace, dbgap_application=dbgap_application, note="foo"
+            workspace=dbgap_workspace,
+            dbgap_application=dbgap_application,
+            note="foo",
         )
         expected_url = reverse(
             "anvil_consortium_manager:managed_groups:member_groups:delete",
@@ -86,6 +92,7 @@ class AuditResultTest(TestCase):
             ],
         )
         self.assertEqual(instance.get_action_url(), expected_url)
+        self.assertTrue(instance.has_access)
 
     def test_error(self):
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
@@ -95,6 +102,7 @@ class AuditResultTest(TestCase):
             dbgap_application=dar.dbgap_data_access_snapshot.dbgap_application,
             data_access_request=dar,
             note="foo",
+            has_access=True,
         )
         self.assertIsNone(instance.get_action_url())
 
@@ -102,7 +110,10 @@ class AuditResultTest(TestCase):
         dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
         dbgap_application = factories.dbGaPApplicationFactory.create()
         instance = audit.Error(
-            workspace=dbgap_workspace, dbgap_application=dbgap_application, note="foo"
+            workspace=dbgap_workspace,
+            dbgap_application=dbgap_application,
+            note="foo",
+            has_access=True,
         )
         self.assertIsNone(instance.get_action_url())
 
@@ -116,6 +127,7 @@ class AuditResultTest(TestCase):
                 dbgap_application=other_application,
                 data_access_request=dar,
                 note="foo",
+                has_access=False,
             )
 
 

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -4235,15 +4235,14 @@ class dbGaPWorkspaceAuditTest(TestCase):
             )
         )
         self.assertIn("data_access_audit", response.context_data)
+        data_access_audit = response.context_data["data_access_audit"]
         self.assertIsInstance(
-            response.context_data["data_access_audit"],
-            audit.dbGaPWorkspaceAccessAudit,
+            data_access_audit,
+            audit.dbGaPAccessAudit,
         )
-        self.assertTrue(response.context_data["data_access_audit"].completed)
-        self.assertEqual(
-            response.context_data["data_access_audit"].dbgap_workspace,
-            self.dbgap_workspace,
-        )
+        self.assertTrue(data_access_audit.completed)
+        self.assertEqual(data_access_audit.dbgap_workspace_queryset.count(), 1)
+        self.assertIn(self.dbgap_workspace, data_access_audit.dbgap_workspace_queryset)
 
     def test_context_verified_table_access(self):
         """verified_table shows a record when audit has verified access."""
@@ -4276,7 +4275,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertEqual(table.rows[0].get_cell_value("data_access_request"), dar)
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPWorkspaceAccessAudit.APPROVED_DAR,
+            audit.dbGaPAccessAudit.APPROVED_DAR,
         )
         self.assertIsNone(table.rows[0].get_cell_value("action"))
 
@@ -4304,7 +4303,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertIsNone(table.rows[0].get_cell_value("data_access_request"))
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPWorkspaceAccessAudit.NO_SNAPSHOTS,
+            audit.dbGaPAccessAudit.NO_SNAPSHOTS,
         )
         self.assertIsNone(table.rows[0].get_cell_value("action"))
 
@@ -4332,7 +4331,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertIsNone(table.rows[0].get_cell_value("data_access_request"))
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPWorkspaceAccessAudit.NO_DAR,
+            audit.dbGaPAccessAudit.NO_DAR,
         )
         self.assertIsNone(table.rows[0].get_cell_value("action"))
 
@@ -4364,7 +4363,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertIsNone(table.rows[0].get_cell_value("data_access_request"))
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPWorkspaceAccessAudit.NO_DAR,
+            audit.dbGaPAccessAudit.NO_DAR,
         )
         self.assertIsNone(table.rows[0].get_cell_value("action"))
 
@@ -4395,7 +4394,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertEqual(table.rows[0].get_cell_value("data_access_request"), dar)
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPWorkspaceAccessAudit.DAR_NOT_APPROVED,
+            audit.dbGaPAccessAudit.DAR_NOT_APPROVED,
         )
         self.assertIsNone(table.rows[0].get_cell_value("action"))
 
@@ -4425,7 +4424,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertEqual(table.rows[0].get_cell_value("data_access_request"), dar)
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPWorkspaceAccessAudit.NEW_APPROVED_DAR,
+            audit.dbGaPAccessAudit.NEW_APPROVED_DAR,
         )
         self.assertIsNotNone(table.rows[0].get_cell_value("action"))
 
@@ -4472,7 +4471,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertEqual(table.rows[0].get_cell_value("data_access_request"), dar)
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPApplicationAccessAudit.PREVIOUS_APPROVAL,
+            audit.dbGaPAccessAudit.PREVIOUS_APPROVAL,
         )
         self.assertIsNotNone(table.rows[0].get_cell_value("action"))
 
@@ -4509,7 +4508,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertEqual(table.rows[0].get_cell_value("data_access_request"), dar)
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPApplicationAccessAudit.ERROR_HAS_ACCESS,
+            audit.dbGaPAccessAudit.ERROR_HAS_ACCESS,
         )
         self.assertIsNotNone(table.rows[0].get_cell_value("action"))
 
@@ -4542,7 +4541,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertIsNone(table.rows[0].get_cell_value("data_access_request"))
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPWorkspaceAccessAudit.ERROR_HAS_ACCESS,
+            audit.dbGaPAccessAudit.ERROR_HAS_ACCESS,
         )
         self.assertIsNotNone(table.rows[0].get_cell_value("action"))
 
@@ -4575,7 +4574,7 @@ class dbGaPWorkspaceAuditTest(TestCase):
         self.assertIsNone(table.rows[0].get_cell_value("data_access_request"))
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.dbGaPWorkspaceAccessAudit.ERROR_HAS_ACCESS,
+            audit.dbGaPAccessAudit.ERROR_HAS_ACCESS,
         )
         self.assertIsNotNone(table.rows[0].get_cell_value("action"))
 

--- a/primed/dbgap/urls.py
+++ b/primed/dbgap/urls.py
@@ -102,9 +102,10 @@ records_patterns = (
 
 
 urlpatterns = [
-    path("studies/", include(dbgap_study_accession_patterns)),
     path("applications/", include(dbgap_application_patterns)),
+    path("audit/", views.dbGaPAudit.as_view(), name="audit"),
     path("dars/", include(data_access_request_patterns)),
-    path("workspaces/", include(dbgap_workspace_patterns)),
     path("records/", include(records_patterns)),
+    path("studies/", include(dbgap_study_accession_patterns)),
+    path("workspaces/", include(dbgap_workspace_patterns)),
 ]

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -587,7 +587,9 @@ class dbGaPApplicationAudit(AnVILConsortiumManagerStaffViewRequired, DetailView)
         context["latest_snapshot"] = latest_snapshot
         if latest_snapshot:
             # Run the audit.
-            data_access_audit = audit.dbGaPApplicationAccessAudit(self.object)
+            data_access_audit = audit.dbGaPAccessAudit(
+                dbgap_application_queryset=self.model.objects.filter(pk=self.object.pk)
+            )
             data_access_audit.run_audit()
             context["verified_table"] = data_access_audit.get_verified_table()
             context["errors_table"] = data_access_audit.get_errors_table()

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -629,7 +629,9 @@ class dbGaPWorkspaceAudit(AnVILConsortiumManagerStaffViewRequired, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         # Run the audit.
-        data_access_audit = audit.dbGaPWorkspaceAccessAudit(self.object)
+        data_access_audit = audit.dbGaPAccessAudit(
+            dbgap_workspace_queryset=self.model.objects.filter(pk=self.object.pk)
+        )
         data_access_audit.run_audit()
         context["verified_table"] = data_access_audit.get_verified_table()
         context["errors_table"] = data_access_audit.get_errors_table()

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -552,6 +552,24 @@ class dbGaPDataAccessRequestHistory(
         return context
 
 
+class dbGaPAudit(AnVILConsortiumManagerStaffViewRequired, TemplateView):
+    """View to audit access for all dbGaPApplications and dbGaPWorkspaces."""
+
+    template_name = "dbgap/dbgap_audit.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Run the audit.
+        data_access_audit = audit.dbGaPAccessAudit()
+        data_access_audit.run_audit()
+        print(data_access_audit.get_verified_table())
+        context["verified_table"] = data_access_audit.get_verified_table()
+        context["errors_table"] = data_access_audit.get_errors_table()
+        context["needs_action_table"] = data_access_audit.get_needs_action_table()
+        context["data_access_audit"] = data_access_audit
+        return context
+
+
 class dbGaPApplicationAudit(AnVILConsortiumManagerStaffViewRequired, DetailView):
     """View to show audit results for a `dbGaPApplication`."""
 

--- a/primed/templates/dbgap/dbgap_audit.html
+++ b/primed/templates/dbgap/dbgap_audit.html
@@ -1,0 +1,49 @@
+{% extends "anvil_consortium_manager/base.html" %}
+{% load django_tables2 %}
+
+{% block title %}dbGaP access audit{% endblock %}
+
+
+{% block content %}
+
+<h1>dbGaP access audit</h1>
+
+<div class="my-3 p-3 bg-light border rounded shadow-sm">
+    Auditing accesss to all dbGaP workspaces for all dbGaP applications.
+</div>
+
+<h2>Audit results</h2>
+
+<div class="my-3 p-3 bg-light border rounded shadow-sm">
+  <p>
+    For each dbGaP workspace and application in the app, the audit checks that access is correct.
+    To have access to a workspace, the group associated with the dbGaP application must be a member of the authorization domain of that workspace. It does not check that the workspace is shared with the group.
+  </p>
+  <p>The audit result categories are explained below.
+    <ul>
+
+      <li><b>Verified</b> includes the following:</li>
+        <ul>
+          <li>No DAR is associated with this workspace and the group does not have access.</li>
+          <li>There is a DAR associated with this workspace, but it is not approved, and the group does nto have access.</li>
+          <li>There is an approved DAR associated with this workspace and the group has access.</li>
+        </ul>
+
+      <li><b>Needs action</b> includes the following:</li>
+      <ul>
+        <li>There is an approved DAR for this workspace, but the group does not have access.</li>
+        <li>A DAR that used to be approved for this workspace is no longer approved, and the group has access.</li>
+      </ul>
+
+      <li><b>Errors</b></li>
+      <ul>
+        <li>The group has access to a workspace for an unknown reason.</li>
+      </ul>
+    </ul>
+  </p>
+  <p>Any errors should be reported!</p>
+</div>
+
+{% include "__audit_tables.html" with verified_table=verified_table needs_action_table=needs_action_table errors_table=errors_table %}
+
+{% endblock content %}

--- a/primed/templates/dbgap/nav_items.html
+++ b/primed/templates/dbgap/nav_items.html
@@ -20,14 +20,19 @@
     <li>
       <a class="dropdown-item" href="{% url 'dbgap:dars:current' %}">List all current DARs</a>
     </li>
-  {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_edit %}
-      <li>
-        <a class="dropdown-item" href="{% url 'dbgap:dbgap_applications:new' %}">Add a new dbGaP application</a>
-      </li>
-      <li>
-        <a class="dropdown-item" href="{% url 'dbgap:dbgap_applications:update_dars' %}">Update DARs for all applications</a>
-      </li>
-      {% endif %}
+    {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_edit %}
+    <li>
+      <a class="dropdown-item" href="{% url 'dbgap:dbgap_applications:new' %}">Add a new dbGaP application</a>
+    </li>
+    <li>
+      <a class="dropdown-item" href="{% url 'dbgap:dbgap_applications:update_dars' %}">Update DARs for all applications</a>
+    </li>
+    {% endif %}
+    {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
+    <li>
+      <a class="dropdown-item" href="{% url 'dbgap:audit' %}">Audit dbGaP access</a>
+    </li>
+    {% endif %}
 
     <li><hr class="dropdown-divider"></li>
 


### PR DESCRIPTION
Add a view to do a "full" audit of dbGaP access, which audits access to all dbGaPWorkspaces for all dbGaPApplications.

- Refactor dbGaP auditing classes to use only one class without duplicated code.
- Add a new view to audit all application/workspace combos.
