### PR TITLE
Convert pytest warnings to errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
     env:
       # mysql://user:password@host:port/database
       DATABASE_URL: "mysql://root:root@127.0.0.1:3306/mysql"
+      # We can set this to an empty string, since we'll never make an API call.
+      ANVIL_API_SERVICE_ACCOUNT_FILE: foo
+
 
     steps:
 
@@ -102,6 +105,10 @@ jobs:
   pytest-sqlite:
     runs-on: ubuntu-latest
 
+    env:
+      # We can set this to an empty string, since we'll never make an API call.
+      ANVIL_API_SERVICE_ACCOUNT_FILE: foo
+
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
@@ -126,9 +133,6 @@ jobs:
 
       - name: Run tests
         run:  coverage run -p -m pytest
-        env:
-          # We can set this to an empty string, since we'll never make an API call.
-          ANVIL_API_SERVICE_ACCOUNT_FILE: foo
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
           pip install pip-tools
           pip-sync requirements/requirements.txt requirements/test-requirements.txt
 
+      - name: Collect staticfiles
+        run: python manage.py collectstatic --noinput
+
       - name: Run tests
         run:  coverage run -p -m pytest
         env:
@@ -117,6 +120,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install pip-tools
           pip-sync requirements/requirements.txt requirements/test-requirements.txt
+
+      - name: Collect staticfiles
+        run: python manage.py collectstatic --noinput
 
       - name: Run tests
         run:  coverage run -p -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           pip-sync requirements/requirements.txt requirements/test-requirements.txt
 
       - name: Collect staticfiles
-        run: python manage.py collectstatic --noinput
+        run: python manage.py collectstatic --noinput --settings=config.settings.test
 
       - name: Run tests
         run:  coverage run -p -m pytest
@@ -129,7 +129,7 @@ jobs:
           pip-sync requirements/requirements.txt requirements/test-requirements.txt
 
       - name: Collect staticfiles
-        run: python manage.py collectstatic --noinput
+        run: python manage.py collectstatic --noinput --settings=config.settings.test
 
       - name: Run tests
         run:  coverage run -p -m pytest

--- a/primed/cdsa/tests/test_commands.py
+++ b/primed/cdsa/tests/test_commands.py
@@ -18,6 +18,9 @@ class CDSARecordsTest(TestCase):
         self.tmpdir = tempfile.TemporaryDirectory()
         self.outdir = os.path.join(self.tmpdir.name, "test_output")
 
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
     def test_output(self):
         out = StringIO()
         call_command("cdsa_records", self.outdir, "--no-color", stdout=out)

--- a/primed/cdsa/tests/test_views.py
+++ b/primed/cdsa/tests/test_views.py
@@ -4646,7 +4646,6 @@ class NonDataAffiliateAgreementCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("form", response.context_data)
         form = response.context_data["form"]
         self.assertFalse(form.is_valid())
-        print(form.errors)
         self.assertEqual(len(form.errors), 1)
         self.assertIn("is_primary", form.errors)
         self.assertEqual(len(form.errors["is_primary"]), 1)

--- a/primed/cdsa/views.py
+++ b/primed/cdsa/views.py
@@ -147,7 +147,6 @@ class AgreementVersionDetail(
     def get_table_data(self):
         qs = models.SignedAgreement.objects.filter(version=self.object)
         # import ipdb; ipdb.set_trace()
-        print(qs)
         return qs
 
     def get_object(self, queryset=None):

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -562,7 +562,6 @@ class dbGaPAudit(AnVILConsortiumManagerStaffViewRequired, TemplateView):
         # Run the audit.
         data_access_audit = audit.dbGaPAccessAudit()
         data_access_audit.run_audit()
-        print(data_access_audit.get_verified_table())
         context["verified_table"] = data_access_audit.get_verified_table()
         context["errors_table"] = data_access_audit.get_errors_table()
         context["needs_action_table"] = data_access_audit.get_needs_action_table()

--- a/primed/duo/management/commands/load_duo.py
+++ b/primed/duo/management/commands/load_duo.py
@@ -33,7 +33,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        print(options)
         # Error if anything is loaded into either model.
         if (
             models.DataUsePermission.objects.exists()
@@ -103,7 +102,6 @@ class Command(BaseCommand):
         return comment
 
     def _create_permission(self, term, parent=None):
-        print("parent {} - term {}".format(parent, term))
         obj = models.DataUsePermission(
             identifier=term.id,
             abbreviation=self._get_term_abbreviation(term),
@@ -118,7 +116,6 @@ class Command(BaseCommand):
             self._create_permission(child, parent=obj)
 
     def _create_modifier(self, term, parent=None):
-        print("parent {} - term {}".format(parent, term))
         if term.obsolete:
             return
         obj = models.DataUseModifier(

--- a/primed/primed_anvil/tests/test_helpers.py
+++ b/primed/primed_anvil/tests/test_helpers.py
@@ -175,7 +175,6 @@ class GetSummaryTableDataTest(TestCase):
         )
         dbgap_workspace_2.available_data.add(available_data_2)
         res = helpers.get_summary_table_data()
-        print(res)
         self.assertEqual(len(res), 2)
         self.assertIn(
             {

--- a/primed/primed_anvil/views.py
+++ b/primed/primed_anvil/views.py
@@ -106,7 +106,6 @@ class StudyAutocomplete(
 
     def get_result_label(self, result):
         s = "{} ({})".format(result.full_name, result.short_name)
-        print(s)
         return s
 
     def get_selected_result_label(self, result):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 addopts = --ds=config.settings.test --reuse-db
 python_files = tests.py test_*.py
+filterwarnings =
+    # Convert all warnings to errors.
+    error

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ python_files = tests.py test_*.py
 filterwarnings =
     # Convert all warnings to errors.
     error
+    # The most recent version of model_utils tries to use pkg_resources, which raises a warning.
+    ignore:pkg_resources is deprecated as an API.:DeprecationWarning:model_utils

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,5 @@ filterwarnings =
     error
     # The most recent version of model_utils tries to use pkg_resources, which raises a warning.
     ignore:pkg_resources is deprecated as an API.:DeprecationWarning:model_utils
+    # Warning raised by pkg_resources via model_utils. ??
+    ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning:pkg_resources


### PR DESCRIPTION
Convert all warnings to errors when running pytest. This should help catch DeprecationErrors that are raised in dependabot updates.

As part of this, add some additional filters to the pytest file to ignore warnings that we don't have control over (e.g., those raised by third-party packages).