### PR TITLE
Change the appearance of the gsr_restricted field on the site

### DIFF
--- a/primed/cdsa/tables.py
+++ b/primed/cdsa/tables.py
@@ -310,7 +310,9 @@ class CDSAWorkspaceStaffTable(tables.Table):
         verbose_name="DUO modifiers",
         linkify_item=True,
     )
-    cdsaworkspace__gsr_restricted = BooleanIconColumn(orderable=False)
+    cdsaworkspace__gsr_restricted = BooleanIconColumn(
+        orderable=False, true_icon="dash-circle-fill", true_color="#ffc107"
+    )
     is_shared = WorkspaceSharedWithConsortiumColumn()
 
     class Meta:

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -96,7 +96,9 @@ class dbGaPWorkspaceStaffTable(tables.Table):
         verbose_name="Approved DARs",
         orderable=False,
     )
-    dbgapworkspace__gsr_restricted = BooleanIconColumn(orderable=False)
+    dbgapworkspace__gsr_restricted = BooleanIconColumn(
+        orderable=False, true_icon="dash-circle-fill", true_color="#ffc107"
+    )
     is_shared = WorkspaceSharedWithConsortiumColumn()
 
     class Meta:

--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -11,20 +11,32 @@ class BooleanIconColumn(tables.BooleanColumn):
     #    attrs = {"td": {"align": "center"}}
     # attrs = {"th": {"class": "center"}}
 
-    def __init__(self, show_false_icon=False, **kwargs):
+    def __init__(
+        self,
+        show_false_icon=False,
+        true_color="green",
+        false_color="red",
+        true_icon="check-circle-fill",
+        false_icon="x-circle-fill",
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.show_false_icon = show_false_icon
+        self.true_color = true_color
+        self.false_color = false_color
+        self.true_icon = true_icon
+        self.false_icon = false_icon
 
     def render(self, value, record, bound_column):
         value = self._get_bool_value(record, value, bound_column)
         if value:
             rendered_value = format_html(
-                """<i class="bi bi-check-circle-fill bi-align-center px-2" style="color: green;"></i>"""
+                f"""<i class="bi bi-{self.true_icon} bi-align-center px-2" style="color: {self.true_color};"></i>"""
             )
         else:
             if self.show_false_icon:
                 rendered_value = format_html(
-                    """<i class="bi bi-x-circle-fill bi-align-center px-2" style="color: red;"></i>"""
+                    f"""<i class="bi bi-{self.false_icon} bi-align-center px-2" style="color: {self.false_color};"></i>"""  # noqa: E501
                 )
             else:
                 rendered_value = ""

--- a/primed/primed_anvil/tests/test_tables.py
+++ b/primed/primed_anvil/tests/test_tables.py
@@ -187,6 +187,40 @@ class BooleanIconColumnTest(TestCase):
         self.assertIn("bi-x-circle-fill", value)
         self.assertIn("red", value)
 
+    def test_true_color(self):
+        column = tables.BooleanIconColumn(true_color="blue")
+        value = column.render(True, None, None)
+        self.assertIn("bi-check-circle-fill", value)
+        self.assertIn("blue", value)
+        value = column.render(False, None, None)
+        self.assertEqual(value, "")
+
+    def test_true_icon(self):
+        column = tables.BooleanIconColumn(true_icon="dash")
+        value = column.render(True, None, None)
+        self.assertIn("bi-dash", value)
+        self.assertIn("green", value)
+        value = column.render(False, None, None)
+        self.assertEqual(value, "")
+
+    def test_false_color(self):
+        column = tables.BooleanIconColumn(show_false_icon=True, false_color="blue")
+        value = column.render(False, None, None)
+        self.assertIn("bi-x-circle-fill", value)
+        self.assertIn("blue", value)
+        value = column.render(True, None, None)
+        self.assertIn("bi-check-circle-fill", value)
+        self.assertIn("green", value)
+
+    def test_false_icon(self):
+        column = tables.BooleanIconColumn(show_false_icon=True, false_icon="dash")
+        value = column.render(False, None, None)
+        self.assertIn("bi-dash", value)
+        self.assertIn("red", value)
+        value = column.render(True, None, None)
+        self.assertIn("bi-check-circle-fill", value)
+        self.assertIn("green", value)
+
 
 class WorkspaceSharedWithConsortiumColumnTest(TestCase):
     """Tests for the WorkspaceSharedWithConsortiumColumn class."""

--- a/primed/templates/cdsa/cdsaworkspace_detail.html
+++ b/primed/templates/cdsa/cdsaworkspace_detail.html
@@ -2,15 +2,7 @@
 
 {% block pills %}
   {% if workspace_data_object.gsr_restricted %}
-  <span class="badge bg-warning text-dark">
-    <span class="me-2 fa-solid fa-circle-minus"></span>
-      GSR posting restricted
-    <span class="ms-2 fa-solid fa-circle-question"
-    data-bs-toggle="tooltip"
-    data-bs-placement="bottom"
-    data-bs-title="This workspace contains sensitive data and therefore public posting of Genomic Summary Results (GSR) is prohibited; see also NOT-19-023."
-    ></span>
-  </span>
+    {% include "snippets/gsr_restricted_badge.html" %}
   {% endif %}
 
 {{ block.super }}

--- a/primed/templates/cdsa/cdsaworkspace_detail.html
+++ b/primed/templates/cdsa/cdsaworkspace_detail.html
@@ -3,7 +3,7 @@
 {% block pills %}
   {% if workspace_data_object.gsr_restricted %}
   <span class="badge bg-warning text-dark">
-    <span class="me-2 fa-solid fa-hand"></span>
+    <span class="me-2 fa-solid fa-circle-minus"></span>
       GSR posting restricted
     <span class="ms-2 fa-solid fa-circle-question"
     data-bs-toggle="tooltip"

--- a/primed/templates/dbgap/dbgapworkspace_detail.html
+++ b/primed/templates/dbgap/dbgapworkspace_detail.html
@@ -2,16 +2,9 @@
 
 {% block pills %}
   {% if workspace_data_object.gsr_restricted %}
-  <span class="badge bg-warning text-dark">
-    <span class="me-2 fa-solid fa-circle-minus"></span>
-      GSR posting restricted
-    <span class="ms-2 fa-solid fa-circle-question"
-    data-bs-toggle="tooltip"
-    data-bs-placement="bottom"
-    data-bs-title="This workspace contains sensitive data and therefore public posting of Genomic Summary Results (GSR) is prohibited; see also NOT-19-023."
-    ></span>
-  </span>
+    {% include "snippets/gsr_restricted_badge.html" %}
   {% endif %}
+
 
 {{ block.super }}
 {% endblock pills %}

--- a/primed/templates/dbgap/dbgapworkspace_detail.html
+++ b/primed/templates/dbgap/dbgapworkspace_detail.html
@@ -3,7 +3,7 @@
 {% block pills %}
   {% if workspace_data_object.gsr_restricted %}
   <span class="badge bg-warning text-dark">
-    <span class="me-2 fa-solid fa-hand"></span>
+    <span class="me-2 fa-solid fa-circle-minus"></span>
       GSR posting restricted
     <span class="ms-2 fa-solid fa-circle-question"
     data-bs-toggle="tooltip"

--- a/primed/templates/snippets/gsr_restricted_badge.html
+++ b/primed/templates/snippets/gsr_restricted_badge.html
@@ -1,0 +1,9 @@
+<span class="badge bg-warning text-dark">
+    <span class="me-2 fa-solid fa-circle-minus"></span>
+      GSR posting restricted
+    <span class="ms-2 fa-solid fa-circle-question"
+    data-bs-toggle="tooltip"
+    data-bs-placement="bottom"
+    data-bs-title="This workspace contains sensitive data and therefore public posting of Genomic Summary Results (GSR) is prohibited; see also NOT-19-023."
+    ></span>
+</span>


### PR DESCRIPTION
- Update BooleanIconColumn to allow the user to specify the Bootstrap icon and the color to color it
- Use a yellow color with a dash/minus icon for the gsr_restricted columns in workspace list tables
- Change the icon for gsr_restricted on detail pages to match the icon in the columns
- Move the gsr_posting_restricted badge into its own snippet