### PR TITLE
Try allowing only "direct" dependency types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,7 @@ updates:
     schedule:
       interval: "daily"
     allow:
-      # Allow both direct and indirect updates for all packages
-      - dependency-type: "all"
+      - dependency-type: "direct"
     # Allow up to 10 dependencies for pip dependencies
     open-pull-requests-limit: 20
 


### PR DESCRIPTION
I think this is ok since dependencies are handled by pip-sync?