### PR TITLE
Use only direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       interval: "weekly"
       day: "sunday"
     allow:
-      # Allow both direct and indirect updates for all packages
-      - dependency-type: "all"
+      # Allow only direct dependencies - should be ok with pip-sync?
+      - dependency-type: "direct"
     # Allow up to 20 dependencies for pip dependencies
     open-pull-requests-limit: 20


### PR DESCRIPTION
As before, dependabot was timing out.