### PR TITLE
Check copy-paste text in form fields and alert if it exceeds maxlength

### DIFF
--- a/primed/static/js/project.js
+++ b/primed/static/js/project.js
@@ -2,7 +2,7 @@
 
 // Handle paste event for text inputs with maxlength.
 const checkPasteLength = (e) => {
-	var paste = (event.clipboardData || window.clipboardData).getData("text");
+	var paste = (e.clipboardData || window.clipboardData).getData("text");
 	maxlength = e.target.getAttribute("maxlength");
   if (paste.length > maxlength) {
     alert("String longer than allowed maximum length of " + maxlength + " characters:\n" + paste)
@@ -12,4 +12,8 @@ const checkPasteLength = (e) => {
 }
 
 var textInputs = $('form').find("input[maxlength]")
-textInputs.on("paste", checkPasteLength);
+// textInputs.on("paste", checkPasteLength);
+for(var i = 0; i < textInputs.length; i++){
+  // Console: print the clicked <p> element
+  textInputs[i].addEventListener("paste", checkPasteLength);
+}

--- a/primed/static/js/project.js
+++ b/primed/static/js/project.js
@@ -1,1 +1,15 @@
 /* Project specific Javascript goes here. */
+
+// Handle paste event for text inputs with maxlength.
+const checkPasteLength = (e) => {
+	var paste = (event.clipboardData || window.clipboardData).getData("text");
+	maxlength = e.target.getAttribute("maxlength");
+  if (maxlength <= paste.length) {
+    alert("String longer than allowed maximum length of " + maxlength + " characters:\n" + paste)
+    e.preventDefault()
+    e.stopPropagation()
+  }
+}
+
+var textInputs = $('form').find("input[maxlength]")
+textInputs.on("paste", checkPasteLength);

--- a/primed/static/js/project.js
+++ b/primed/static/js/project.js
@@ -4,7 +4,7 @@
 const checkPasteLength = (e) => {
 	var paste = (event.clipboardData || window.clipboardData).getData("text");
 	maxlength = e.target.getAttribute("maxlength");
-  if (maxlength <= paste.length) {
+  if (paste.length > maxlength) {
     alert("String longer than allowed maximum length of " + maxlength + " characters:\n" + paste)
     e.preventDefault()
     e.stopPropagation()


### PR DESCRIPTION
In form input fields with the maxlength attribute, add custom javascript that prevents pasting text with more than maxlength characters. This can help prevent data truncation when pasting more characters than maxlength allows, since by default they would be silently truncated.

Closes #491 