### PR TITLE
Add ability to show banner announcements

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -371,7 +371,9 @@ DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
 
 # django-constance
 # ------------------------------------------------------------------------------
-CONSTANCE_CONFIG = {}
+CONSTANCE_CONFIG = {
+    "SITE_ANNOUNCEMENT": ("", "Site-wide announcement message", str),
+}
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 CONSTANCE_IGNORE_ADMIN_VERSION_CHECK = True
 # CONSTANCE_DATABASE_CACHE_BACKEND = "default"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -374,7 +374,8 @@ DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
 CONSTANCE_CONFIG = {}
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 CONSTANCE_IGNORE_ADMIN_VERSION_CHECK = True
-CONSTANCE_DATABASE_CACHE_BACKEND = "default"
+# CONSTANCE_DATABASE_CACHE_BACKEND = "default"
+CONSTANCE_DATABASE_CACHE_AUTOFILL_TIMEOUT = None
 
 # django-anvil-consortium-manager
 # ------------------------------------------------------------------------------

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -86,6 +86,7 @@ THIRD_PARTY_APPS = [
     "dbbackup",
     "django_htmx",
     "constance",
+    "constance.backends.database",
 ]
 
 LOCAL_APPS = [

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -85,6 +85,7 @@ THIRD_PARTY_APPS = [
     "simple_history",
     "dbbackup",
     "django_htmx",
+    "constance",
 ]
 
 LOCAL_APPS = [
@@ -367,6 +368,13 @@ DCC_CONTACT_EMAIL = "primedconsortium@uw.edu"
 # ------------------------------------------------------------------------------
 # https://django-tables2.readthedocs.io/en/latest/pages/custom-rendering.html?highlight=django_tables2_template#available-templates
 DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
+
+# django-constance
+# ------------------------------------------------------------------------------
+CONSTANCE_CONFIG = {}
+CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
+CONSTANCE_IGNORE_ADMIN_VERSION_CHECK = True
+CONSTANCE_DATABASE_CACHE_BACKEND = "default"
 
 # django-anvil-consortium-manager
 # ------------------------------------------------------------------------------

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -207,6 +207,7 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
+                "constance.context_processors.config",
                 "primed.utils.context_processors.settings_context",
             ],
         },
@@ -373,8 +374,9 @@ DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
 # django-constance
 # ------------------------------------------------------------------------------
 CONSTANCE_CONFIG = {
-    "SITE_ANNOUNCEMENT": ("", "Site-wide announcement message", str),
+    "ANNOUNCEMENT_TEXT": ("", "Site-wide announcement message", str),
 }
+
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 CONSTANCE_IGNORE_ADMIN_VERSION_CHECK = True
 # CONSTANCE_DATABASE_CACHE_BACKEND = "default"

--- a/primed/primed_anvil/tests/test_views.py
+++ b/primed/primed_anvil/tests/test_views.py
@@ -3,6 +3,7 @@ import json
 from anvil_consortium_manager import models as acm_models
 from anvil_consortium_manager.tests.factories import AccountFactory
 from anvil_consortium_manager.views import AccountList
+from constance.test import override_config
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -168,6 +169,24 @@ class HomeTest(TestCase):
         self.assertNotContains(
             response, '"{}"'.format(reverse("anvil_consortium_manager:index"))
         )
+
+    def test_site_announcement_no_text(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url())
+        self.assertNotContains(response, """id="alert-announcement""")
+
+    @override_config(ANNOUNCEMENT_TEXT="This is a test announcement")
+    def test_site_announcement_text(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url())
+        self.assertContains(response, """id="alert-announcement""")
+        self.assertContains(response, "This is a test announcement")
+
+    @override_config(ANNOUNCEMENT_TEXT="This is a test announcement")
+    def test_site_announcement_text_unauthenticated_user(self):
+        response = self.client.get(self.get_url(), follow=True)
+        self.assertContains(response, """id="alert-announcement""")
+        self.assertContains(response, "This is a test announcement")
 
 
 class StudyDetailTest(TestCase):

--- a/primed/primed_anvil/tests/test_views.py
+++ b/primed/primed_anvil/tests/test_views.py
@@ -133,6 +133,12 @@ class HomeTest(TestCase):
             response, reverse("anvil_consortium_manager:accounts:link")
         )
 
+    def test_unauthenticated_user_has_not_linked_account_message(self):
+        response = self.client.get(settings.LOGIN_URL, follow=True)
+        self.assertNotContains(
+            response, reverse("anvil_consortium_manager:accounts:link")
+        )
+
     def test_staff_view_links(self):
         user = UserFactory.create()
         user.user_permissions.add(

--- a/primed/static/css/project.css
+++ b/primed/static/css/project.css
@@ -134,7 +134,6 @@ h3, .h3 {
 }
 
 h4, .h4 {
-  font-size: calc(1.275rem + 0.3vw);
 }
 
 @media (min-width: 1200px) {
@@ -12012,9 +12011,6 @@ a.navbar-brand:hover {
   background-color: unset;
 }
 
-.navbar {
-  min-height: 132px;
-}
 
 .navbar-brand {
   height: 100px;

--- a/primed/templates/base.html
+++ b/primed/templates/base.html
@@ -120,12 +120,11 @@
       {% endif %}
 
       {% if not request.user.account %}
-      <div class="alert alert-info" role="alert">
+      <div class="alert alert-warning" role="alert">
         <i class="bi bi-exclamation-triangle-fill me-1"></i>
         You must <a href="{% url 'anvil_consortium_manager:accounts:link' %}">link your AnVIL account</a> before you can access any data on AnVIL.
       </div>
       {% endif %}
-
 
       {% block content %}
               <div class="my-3 alert alert-warning" role="alert">

--- a/primed/templates/base.html
+++ b/primed/templates/base.html
@@ -119,7 +119,7 @@
           {% endfor %}
       {% endif %}
 
-      {% if not request.user.account %}
+      {% if request.user.is_authenticated and not request.user.account %}
       <div class="alert alert-warning" role="alert">
         <i class="bi bi-exclamation-triangle-fill me-1"></i>
         You must <a href="{% url 'anvil_consortium_manager:accounts:link' %}">link your AnVIL account</a> before you can access any data on AnVIL.

--- a/primed/templates/base.html
+++ b/primed/templates/base.html
@@ -108,23 +108,26 @@
       </div>
     </nav>
 
+    <main class="flex-shrink-0">
+      <div class="container">
+
+    {% if request.user.is_authenticated and not request.user.account %}
+    <div class="alert alert-warning" role="alert">
+      <i class="bi bi-exclamation-triangle-fill me-1"></i>
+      You must <a href="{% url 'anvil_consortium_manager:accounts:link' %}">link your AnVIL account</a> before you can access any data on AnVIL.
+    </div>
+    {% endif %}
+
+    {% if messages %}
+    {% for message in messages %}
+        <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %} alert-dismissible fade show" role="alert">{{ message }}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>
+    {% endfor %}
+{% endif %}
+
     {% block extra_navbar %}
     {% endblock %}
-    <main class="flex-shrink-0">
-    <div class="container">
 
-      {% if messages %}
-          {% for message in messages %}
-              <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %} alert-dismissible fade show" role="alert">{{ message }}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>
-          {% endfor %}
-      {% endif %}
 
-      {% if request.user.is_authenticated and not request.user.account %}
-      <div class="alert alert-warning" role="alert">
-        <i class="bi bi-exclamation-triangle-fill me-1"></i>
-        You must <a href="{% url 'anvil_consortium_manager:accounts:link' %}">link your AnVIL account</a> before you can access any data on AnVIL.
-      </div>
-      {% endif %}
 
       {% block content %}
               <div class="my-3 alert alert-warning" role="alert">

--- a/primed/templates/base.html
+++ b/primed/templates/base.html
@@ -111,18 +111,25 @@
     <main class="flex-shrink-0">
       <div class="container">
 
-    {% if request.user.is_authenticated and not request.user.account %}
-    <div class="alert alert-warning" role="alert">
-      <i class="bi bi-exclamation-triangle-fill me-1"></i>
-      You must <a href="{% url 'anvil_consortium_manager:accounts:link' %}">link your AnVIL account</a> before you can access any data on AnVIL.
-    </div>
+      {% if config.ANNOUNCEMENT_TEXT %}
+        <div class="alert alert-info" role="alert" id="alert-announcement">
+          <i class="bi bi-megaphone-fill me-1"></i>
+          {{ config.ANNOUNCEMENT_TEXT }}
+        </div>
+      {% endif %}
+
+      {% if request.user.is_authenticated and not request.user.account %}
+      <div class="alert alert-warning" role="alert">
+        <i class="bi bi-exclamation-triangle-fill me-1"></i>
+        You must <a href="{% url 'anvil_consortium_manager:accounts:link' %}">link your AnVIL account</a> before you can access any data on AnVIL.
+      </div>
     {% endif %}
 
     {% if messages %}
-    {% for message in messages %}
-        <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %} alert-dismissible fade show" role="alert">{{ message }}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>
-    {% endfor %}
-{% endif %}
+      {% for message in messages %}
+          <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %} alert-dismissible fade show" role="alert">{{ message }}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>
+      {% endfor %}
+    {% endif %}
 
     {% block extra_navbar %}
     {% endblock %}

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -66,3 +66,6 @@ django-htmx
 certifi>=2023.7.22
 urllib3>=1.26.18
 sqlparse>=0.4.4
+
+# Dynamic settings
+django-constance

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -65,6 +65,8 @@ django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-con
     # via -r requirements/requirements.in
 django-autocomplete-light==3.11.0
     # via django-anvil-consortium-manager
+django-constance==2.9.1
+    # via -r requirements/requirements.in
 django-crispy-forms==2.1
     # via
     #   -r requirements/requirements.in
@@ -88,6 +90,9 @@ django-maintenance-mode==0.21.1
     # via -r requirements/requirements.in
 django-model-utils==4.4.0
     # via -r requirements/requirements.in
+django-picklefield==3.1.0
+    # via -r requirements/requirements.in
+    # django-constnace
 django-simple-history==3.5.0
     # via
     #   -r requirements/requirements.in


### PR DESCRIPTION
- Use the django-constance app to add settings that can be edited in the admin
- Add a SITE_ANNOUNCEMENT setting
- If SITE_ANNOUNCEMENT is non-blank, show an alert with the text of the site announcement