### PR TITLE
Add django-picklefield to requirements.in

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -69,3 +69,4 @@ sqlparse>=0.4.4
 
 # Dynamic settings
 django-constance
+django-picklefield  # Required by django-constance for database backend


### PR DESCRIPTION
Forgot to add it - looks like it is not installed as a dependency by django-constance.