### PR TITLE
Consolidate definitions for staff and user tables

### DIFF
--- a/primed/cdsa/adapters.py
+++ b/primed/cdsa/adapters.py
@@ -2,7 +2,7 @@ from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
 from anvil_consortium_manager.forms import WorkspaceForm
 from anvil_consortium_manager.models import Workspace
 
-from primed.miscellaneous_workspaces.tables import DataPrepWorkspaceTable
+from primed.miscellaneous_workspaces.tables import DataPrepWorkspaceUserTable
 
 from . import forms, models, tables
 
@@ -27,7 +27,7 @@ class CDSAWorkspaceAdapter(BaseWorkspaceAdapter):
         associated_data_prep = Workspace.objects.filter(
             dataprepworkspace__target_workspace=workspace
         )
-        extra_context["associated_data_prep_workspaces"] = DataPrepWorkspaceTable(
+        extra_context["associated_data_prep_workspaces"] = DataPrepWorkspaceUserTable(
             associated_data_prep
         )
         extra_context["data_prep_active"] = associated_data_prep.filter(

--- a/primed/cdsa/tables.py
+++ b/primed/cdsa/tables.py
@@ -303,7 +303,6 @@ class CDSAWorkspaceUserTable(tables.Table):
     """A table for the CDSAWorkspace model."""
 
     name = tables.Column(linkify=True)
-    billing_project = tables.Column()
     cdsaworkspace__data_use_permission__abbreviation = tables.Column(
         verbose_name="DUO permission",
         linkify=lambda record: record.cdsaworkspace.data_use_permission.get_absolute_url(),
@@ -329,7 +328,6 @@ class CDSAWorkspaceUserTable(tables.Table):
         model = Workspace
         fields = (
             "name",
-            "billing_project",
             "cdsaworkspace__study",
             "cdsaworkspace__data_use_permission__abbreviation",
             "cdsaworkspace__data_use_modifiers",

--- a/primed/cdsa/tables.py
+++ b/primed/cdsa/tables.py
@@ -299,11 +299,11 @@ class CDSAWorkspaceRecordsTable(tables.Table):
             return "—"
 
 
-class CDSAWorkspaceStaffTable(tables.Table):
+class CDSAWorkspaceUserTable(tables.Table):
     """A table for the CDSAWorkspace model."""
 
     name = tables.Column(linkify=True)
-    billing_project = tables.Column(linkify=True)
+    billing_project = tables.Column()
     cdsaworkspace__data_use_permission__abbreviation = tables.Column(
         verbose_name="DUO permission",
         linkify=lambda record: record.cdsaworkspace.data_use_permission.get_absolute_url(),
@@ -351,27 +351,10 @@ class CDSAWorkspaceStaffTable(tables.Table):
         return mark_safe(f'<i class="bi bi-{icon}" style="color: {color}"></i>')
 
 
-class CDSAWorkspaceUserTable(tables.Table):
+class CDSAWorkspaceStaffTable(CDSAWorkspaceUserTable):
     """A table for the CDSAWorkspace model."""
 
-    name = tables.Column(linkify=True)
-    billing_project = tables.Column()
-    cdsaworkspace__data_use_permission__abbreviation = tables.Column(
-        verbose_name="DUO permission",
-    )
-    cdsaworkspace__study = tables.Column()
-    cdsaworkspace__data_use_modifiers = tables.ManyToManyColumn(
-        transform=lambda x: x.abbreviation,
-        verbose_name="DUO modifiers",
-    )
-    cdsaworkspace__requires_study_review = BooleanIconColumn(
-        verbose_name="Study review required?",
-        orderable=False,
-        true_icon="dash-circle-fill",
-        true_color="#ffc107",
-    )
-    cdsaworkspace__gsr_restricted = BooleanIconColumn(orderable=False)
-    is_shared = WorkspaceSharedWithConsortiumColumn()
+    billing_project = tables.Column(linkify=True)
 
     class Meta:
         model = Workspace
@@ -385,15 +368,3 @@ class CDSAWorkspaceUserTable(tables.Table):
             "cdsaworkspace__gsr_restricted",
         )
         order_by = ("name",)
-
-    def render_cdsaworkspace__requires_study_review(self, record):
-        try:
-            if record.cdsaworkspace.get_primary_cdsa().requires_study_review:
-                icon = "dash-circle-fill"
-                color = "#ffc107"
-            else:
-                return ""
-        except models.DataAffiliateAgreement.DoesNotExist:
-            icon = "question-circle-fill"
-            color = "red"
-        return mark_safe(f'<i class="bi bi-{icon}" style="color: {color}"></i>')

--- a/primed/cdsa/tests/test_views.py
+++ b/primed/cdsa/tests/test_views.py
@@ -30,7 +30,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from primed.duo.tests.factories import DataUseModifierFactory, DataUsePermissionFactory
-from primed.miscellaneous_workspaces.tables import DataPrepWorkspaceTable
+from primed.miscellaneous_workspaces.tables import DataPrepWorkspaceUserTable
 from primed.miscellaneous_workspaces.tests.factories import DataPrepWorkspaceFactory
 from primed.primed_anvil.tests.factories import (
     AvailableDataFactory,
@@ -7443,7 +7443,7 @@ class CDSAWorkspaceDetailTest(TestCase):
         self.assertIn("associated_data_prep_workspaces", response.context_data)
         self.assertIsInstance(
             response.context_data["associated_data_prep_workspaces"],
-            DataPrepWorkspaceTable,
+            DataPrepWorkspaceUserTable,
         )
 
     def test_only_show_one_associated_data_prep_workspace(self):

--- a/primed/cdsa/tests/test_views.py
+++ b/primed/cdsa/tests/test_views.py
@@ -7436,6 +7436,29 @@ class CDSAWorkspaceDetailTest(TestCase):
         self.assertContains(response, modifiers[0].abbreviation)
         self.assertContains(response, modifiers[1].abbreviation)
 
+    def test_associated_data_prep_view_user(self):
+        """View users do not see the associated data prep section"""
+        user = User.objects.create_user(username="test-view", password="test-view")
+        user.user_permissions.add(
+            Permission.objects.get(
+                codename=AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            )
+        )
+
+        obj = factories.CDSAWorkspaceFactory.create()
+        DataPrepWorkspaceFactory.create(target_workspace=obj.workspace)
+        self.client.force_login(user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertNotContains(response, "Associated data prep workspaces")
+
+    def test_associated_data_prep_staff_view_user(self):
+        """Staff view users do see the associated data prep section."""
+        obj = factories.CDSAWorkspaceFactory.create()
+        DataPrepWorkspaceFactory.create(target_workspace=obj.workspace)
+        self.client.force_login(self.user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertContains(response, "Associated data prep workspaces")
+
     def test_associated_data_prep_workspaces_context_exists(self):
         obj = factories.CDSAWorkspaceFactory.create()
         self.client.force_login(self.user)

--- a/primed/collaborative_analysis/tables.py
+++ b/primed/collaborative_analysis/tables.py
@@ -2,33 +2,6 @@ import django_tables2 as tables
 from anvil_consortium_manager.models import Workspace
 
 
-class CollaborativeAnalysisWorkspaceStaffTable(tables.Table):
-    """Class to render a table of Workspace objects with CollaborativeAnalysisWorkspace data."""
-
-    name = tables.columns.Column(linkify=True)
-    billing_project = tables.Column(linkify=True)
-    collaborativeanalysisworkspace__custodian = tables.Column(linkify=True)
-    number_source_workspaces = tables.columns.Column(
-        accessor="pk",
-        verbose_name="Number of source workspaces",
-        orderable=False,
-    )
-
-    class Meta:
-        model = Workspace
-        fields = (
-            "name",
-            "billing_project",
-            "collaborativeanalysisworkspace__custodian",
-            "number_source_workspaces",
-        )
-        order_by = ("name",)
-
-    def render_number_source_workspaces(self, record):
-        """Render the number of source workspaces."""
-        return record.collaborativeanalysisworkspace.source_workspaces.count()
-
-
 class CollaborativeAnalysisWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with CollaborativeAnalysisWorkspace data."""
 
@@ -53,3 +26,21 @@ class CollaborativeAnalysisWorkspaceUserTable(tables.Table):
     def render_number_source_workspaces(self, record):
         """Render the number of source workspaces."""
         return record.collaborativeanalysisworkspace.source_workspaces.count()
+
+
+class CollaborativeAnalysisWorkspaceStaffTable(CollaborativeAnalysisWorkspaceUserTable):
+    """Class to render a table of Workspace objects with CollaborativeAnalysisWorkspace data."""
+
+    name = tables.columns.Column(linkify=True)
+    billing_project = tables.Column(linkify=True)
+    collaborativeanalysisworkspace__custodian = tables.Column(linkify=True)
+
+    class Meta:
+        model = Workspace
+        fields = (
+            "name",
+            "billing_project",
+            "collaborativeanalysisworkspace__custodian",
+            "number_source_workspaces",
+        )
+        order_by = ("name",)

--- a/primed/collaborative_analysis/tables.py
+++ b/primed/collaborative_analysis/tables.py
@@ -6,7 +6,6 @@ class CollaborativeAnalysisWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with CollaborativeAnalysisWorkspace data."""
 
     name = tables.columns.Column(linkify=True)
-    billing_project = tables.Column()
     number_source_workspaces = tables.columns.Column(
         accessor="pk",
         verbose_name="Number of source workspaces",
@@ -17,7 +16,6 @@ class CollaborativeAnalysisWorkspaceUserTable(tables.Table):
         model = Workspace
         fields = (
             "name",
-            "billing_project",
             "collaborativeanalysisworkspace__custodian",
             "number_source_workspaces",
         )

--- a/primed/dbgap/adapters.py
+++ b/primed/dbgap/adapters.py
@@ -2,7 +2,7 @@ from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
 from anvil_consortium_manager.forms import WorkspaceForm
 from anvil_consortium_manager.models import Workspace
 
-from primed.miscellaneous_workspaces.tables import DataPrepWorkspaceTable
+from primed.miscellaneous_workspaces.tables import DataPrepWorkspaceUserTable
 
 from . import forms, models, tables
 
@@ -25,7 +25,7 @@ class dbGaPWorkspaceAdapter(BaseWorkspaceAdapter):
         associated_data_prep = Workspace.objects.filter(
             dataprepworkspace__target_workspace=workspace
         )
-        extra_context["associated_data_prep_workspaces"] = DataPrepWorkspaceTable(
+        extra_context["associated_data_prep_workspaces"] = DataPrepWorkspaceUserTable(
             associated_data_prep
         )
         extra_context["data_prep_active"] = associated_data_prep.filter(

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -78,7 +78,6 @@ class dbGaPWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with dbGaPWorkspace workspace data."""
 
     name = tables.columns.Column(linkify=True)
-    billing_project = tables.Column()
     dbgap_accession = dbGaPAccessionColumn(
         accessor="dbgapworkspace__get_dbgap_accession",
         dbgap_link_accessor="dbgapworkspace__get_dbgap_link",
@@ -100,7 +99,6 @@ class dbGaPWorkspaceUserTable(tables.Table):
         model = Workspace
         fields = (
             "name",
-            "billing_project",
             "dbgap_accession",
             "dbgapworkspace__dbgap_consent_abbreviation",
             "dbgapworkspace__gsr_restricted",

--- a/primed/dbgap/tables.py
+++ b/primed/dbgap/tables.py
@@ -74,11 +74,11 @@ class dbGaPStudyAccessionTable(tables.Table):
         return "phs{0:06d}".format(value)
 
 
-class dbGaPWorkspaceStaffTable(tables.Table):
+class dbGaPWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with dbGaPWorkspace workspace data."""
 
     name = tables.columns.Column(linkify=True)
-    billing_project = tables.Column(linkify=True)
+    billing_project = tables.Column()
     dbgap_accession = dbGaPAccessionColumn(
         accessor="dbgapworkspace__get_dbgap_accession",
         dbgap_link_accessor="dbgapworkspace__get_dbgap_link",
@@ -91,15 +91,33 @@ class dbGaPWorkspaceStaffTable(tables.Table):
     dbgapworkspace__dbgap_consent_abbreviation = tables.columns.Column(
         verbose_name="Consent"
     )
+    dbgapworkspace__gsr_restricted = BooleanIconColumn(
+        orderable=False, true_icon="dash-circle-fill", true_color="#ffc107"
+    )
+    is_shared = WorkspaceSharedWithConsortiumColumn()
+
+    class Meta:
+        model = Workspace
+        fields = (
+            "name",
+            "billing_project",
+            "dbgap_accession",
+            "dbgapworkspace__dbgap_consent_abbreviation",
+            "dbgapworkspace__gsr_restricted",
+            "is_shared",
+        )
+        order_by = ("name",)
+
+
+class dbGaPWorkspaceStaffTable(dbGaPWorkspaceUserTable):
+    """Class to render a table of Workspace objects with dbGaPWorkspace workspace data."""
+
+    billing_project = tables.Column(linkify=True)
     number_approved_dars = tables.columns.Column(
         accessor="pk",
         verbose_name="Approved DARs",
         orderable=False,
     )
-    dbgapworkspace__gsr_restricted = BooleanIconColumn(
-        orderable=False, true_icon="dash-circle-fill", true_color="#ffc107"
-    )
-    is_shared = WorkspaceSharedWithConsortiumColumn()
 
     class Meta:
         model = Workspace
@@ -121,39 +139,6 @@ class dbGaPWorkspaceStaffTable(tables.Table):
             .count()
         )
         return n
-
-
-class dbGaPWorkspaceUserTable(tables.Table):
-    """Class to render a table of Workspace objects with dbGaPWorkspace workspace data."""
-
-    name = tables.columns.Column(linkify=True)
-    billing_project = tables.Column()
-    dbgap_accession = dbGaPAccessionColumn(
-        accessor="dbgapworkspace__get_dbgap_accession",
-        dbgap_link_accessor="dbgapworkspace__get_dbgap_link",
-        order_by=(
-            "dbgapworkspace__dbgap_study_accession__dbgap_phs",
-            "dbgapworkspace__dbgap_version",
-            "dbgapworkspace__dbgap_participant_set",
-        ),
-    )
-    dbgapworkspace__dbgap_consent_abbreviation = tables.columns.Column(
-        verbose_name="Consent"
-    )
-    dbgapworkspace__gsr_restricted = BooleanIconColumn(orderable=False)
-    is_shared = WorkspaceSharedWithConsortiumColumn()
-
-    class Meta:
-        model = Workspace
-        fields = (
-            "name",
-            "billing_project",
-            "dbgap_accession",
-            "dbgapworkspace__dbgap_consent_abbreviation",
-            "dbgapworkspace__gsr_restricted",
-            "is_shared",
-        )
-        order_by = ("name",)
 
 
 class dbGaPApplicationTable(tables.Table):

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -32,7 +32,7 @@ from faker import Faker
 from freezegun import freeze_time
 
 from primed.duo.tests.factories import DataUseModifierFactory, DataUsePermissionFactory
-from primed.miscellaneous_workspaces.tables import DataPrepWorkspaceTable
+from primed.miscellaneous_workspaces.tables import DataPrepWorkspaceUserTable
 from primed.miscellaneous_workspaces.tests.factories import DataPrepWorkspaceFactory
 from primed.primed_anvil.tests.factories import (  # DataUseModifierFactory,; DataUsePermissionFactory,
     StudyFactory,
@@ -960,7 +960,7 @@ class dbGaPWorkspaceDetailTest(TestCase):
         self.assertIn("associated_data_prep_workspaces", response.context_data)
         self.assertIsInstance(
             response.context_data["associated_data_prep_workspaces"],
-            DataPrepWorkspaceTable,
+            DataPrepWorkspaceUserTable,
         )
 
     def test_only_show_one_associated_data_prep_workspace(self):

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -953,6 +953,29 @@ class dbGaPWorkspaceDetailTest(TestCase):
             ),
         )
 
+    def test_associated_data_prep_view_user(self):
+        """View users do not see the associated data prep section"""
+        user = User.objects.create_user(username="test-view", password="test-view")
+        user.user_permissions.add(
+            Permission.objects.get(
+                codename=AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            )
+        )
+
+        obj = factories.dbGaPWorkspaceFactory.create()
+        DataPrepWorkspaceFactory.create(target_workspace=obj.workspace)
+        self.client.force_login(user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertNotContains(response, "Associated data prep workspaces")
+
+    def test_associated_data_prep_staff_view_user(self):
+        """Staff view users do see the associated data prep section."""
+        obj = factories.dbGaPWorkspaceFactory.create()
+        DataPrepWorkspaceFactory.create(target_workspace=obj.workspace)
+        self.client.force_login(self.user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertContains(response, "Associated data prep workspaces")
+
     def test_associated_data_prep_workspaces_context_exists(self):
         obj = factories.dbGaPWorkspaceFactory.create()
         self.client.force_login(self.user)

--- a/primed/miscellaneous_workspaces/adapters.py
+++ b/primed/miscellaneous_workspaces/adapters.py
@@ -93,8 +93,8 @@ class DataPrepWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "data_prep"
     name = "Data prep workspace"
     description = "Workspaces used to prepare data for sharing or update data that is already shared"
-    list_table_class_staff_view = tables.DataPrepWorkspaceTable
-    list_table_class_view = tables.DataPrepWorkspaceTable
+    list_table_class_staff_view = tables.DataPrepWorkspaceStaffTable
+    list_table_class_view = tables.DataPrepWorkspaceUserTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.DataPrepWorkspace
     workspace_data_form_class = forms.DataPrepWorkspaceForm

--- a/primed/miscellaneous_workspaces/tables.py
+++ b/primed/miscellaneous_workspaces/tables.py
@@ -13,7 +13,6 @@ class OpenAccessWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with OpenAccessWorkspace workspace data."""
 
     name = tables.columns.Column(linkify=True)
-    billing_project = tables.Column()
     is_shared = WorkspaceSharedWithConsortiumColumn()
     openaccessworkspace__studies = tables.ManyToManyColumn(
         linkify_item=True,
@@ -23,7 +22,6 @@ class OpenAccessWorkspaceUserTable(tables.Table):
         model = Workspace
         fields = (
             "name",
-            "billing_project",
             "openaccessworkspace__studies",
             "is_shared",
         )

--- a/primed/miscellaneous_workspaces/tables.py
+++ b/primed/miscellaneous_workspaces/tables.py
@@ -44,11 +44,10 @@ class OpenAccessWorkspaceStaffTable(OpenAccessWorkspaceUserTable):
         order_by = ("name",)
 
 
-class DataPrepWorkspaceTable(tables.Table):
+class DataPrepWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with DataPrepWorkspace workspace data."""
 
     name = tables.columns.Column(linkify=True)
-    # TODO: Figure out why this is not showing up
     dataprepworkspace__target_workspace__name = tables.columns.Column(
         linkify=True, verbose_name="Target workspace"
     )
@@ -60,6 +59,22 @@ class DataPrepWorkspaceTable(tables.Table):
         model = Workspace
         fields = (
             "name",
+            "dataprepworkspace__target_workspace__name",
+            "dataprepworkspace__is_active",
+        )
+        order_by = ("name",)
+
+
+class DataPrepWorkspaceStaffTable(DataPrepWorkspaceUserTable):
+    """Class to render a table of Workspace objects with DataPrepWorkspace workspace data."""
+
+    billing_project = tables.columns.Column(linkify=True)
+
+    class Meta:
+        model = Workspace
+        fields = (
+            "name",
+            "billing_project",
             "dataprepworkspace__target_workspace__name",
             "dataprepworkspace__is_active",
         )

--- a/primed/miscellaneous_workspaces/tables.py
+++ b/primed/miscellaneous_workspaces/tables.py
@@ -9,12 +9,15 @@ from primed.primed_anvil.tables import (
 )
 
 
-class OpenAccessWorkspaceStaffTable(tables.Table):
+class OpenAccessWorkspaceUserTable(tables.Table):
     """Class to render a table of Workspace objects with OpenAccessWorkspace workspace data."""
 
     name = tables.columns.Column(linkify=True)
-    billing_project = tables.Column(linkify=True)
+    billing_project = tables.Column()
     is_shared = WorkspaceSharedWithConsortiumColumn()
+    openaccessworkspace__studies = tables.ManyToManyColumn(
+        linkify_item=True,
+    )
 
     class Meta:
         model = Workspace
@@ -27,12 +30,10 @@ class OpenAccessWorkspaceStaffTable(tables.Table):
         order_by = ("name",)
 
 
-class OpenAccessWorkspaceUserTable(tables.Table):
+class OpenAccessWorkspaceStaffTable(OpenAccessWorkspaceUserTable):
     """Class to render a table of Workspace objects with OpenAccessWorkspace workspace data."""
 
-    name = tables.columns.Column(linkify=True)
-    billing_project = tables.Column()
-    is_shared = WorkspaceSharedWithConsortiumColumn()
+    billing_project = tables.Column(linkify=True)
 
     class Meta:
         model = Workspace

--- a/primed/miscellaneous_workspaces/tests/test_tables.py
+++ b/primed/miscellaneous_workspaces/tests/test_tables.py
@@ -49,11 +49,32 @@ class OpenAccessWorkspaceUserTableTest(TestCase):
         self.assertEqual(len(table.rows), 2)
 
 
-class DataPrepWorkspaceTableTest(TestCase):
-    """Tests for the DataPrepWorkspaceTable table."""
+class DataPrepWorkspaceUserTableTest(TestCase):
+    """Tests for the DataPrepWorkspaceUserTable table."""
 
     model_factory = factories.DataPrepWorkspaceFactory
-    table_class = tables.DataPrepWorkspaceTable
+    table_class = tables.DataPrepWorkspaceUserTable
+
+    def test_row_count_with_no_objects(self):
+        table = self.table_class(Workspace.objects.filter(workspace_type="data_prep"))
+        self.assertEqual(len(table.rows), 0)
+
+    def test_row_count_with_one_object(self):
+        self.model_factory.create()
+        table = self.table_class(Workspace.objects.filter(workspace_type="data_prep"))
+        self.assertEqual(len(table.rows), 1)
+
+    def test_row_count_with_two_objects(self):
+        self.model_factory.create_batch(2)
+        table = self.table_class(Workspace.objects.filter(workspace_type="data_prep"))
+        self.assertEqual(len(table.rows), 2)
+
+
+class DataPrepWorkspaceStaffTableTest(TestCase):
+    """Tests for the DataPrepWorkspaceUserTable table."""
+
+    model_factory = factories.DataPrepWorkspaceFactory
+    table_class = tables.DataPrepWorkspaceStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(Workspace.objects.filter(workspace_type="data_prep"))

--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -59,10 +59,24 @@ class WorkspaceSharedWithConsortiumColumn(BooleanIconColumn):
         return is_shared
 
 
-class DefaultWorkspaceStaffTable(tables.Table):
+class DefaultWorkspaceUserTable(tables.Table):
     """Class to use for default workspace tables in PRIMED."""
 
     name = tables.Column(linkify=True, verbose_name="Workspace")
+    is_shared = WorkspaceSharedWithConsortiumColumn()
+
+    class Meta:
+        model = Workspace
+        fields = (
+            "name",
+            "is_shared",
+        )
+        order_by = ("name",)
+
+
+class DefaultWorkspaceStaffTable(DefaultWorkspaceUserTable):
+    """Class to use for default workspace tables in PRIMED."""
+
     billing_project = tables.Column(linkify=True)
     number_groups = tables.Column(
         verbose_name="Number of groups shared with",
@@ -70,7 +84,6 @@ class DefaultWorkspaceStaffTable(tables.Table):
         orderable=False,
         accessor="workspacegroupsharing_set__count",
     )
-    is_shared = WorkspaceSharedWithConsortiumColumn()
 
     class Meta:
         model = Workspace
@@ -78,23 +91,6 @@ class DefaultWorkspaceStaffTable(tables.Table):
             "name",
             "billing_project",
             "number_groups",
-            "is_shared",
-        )
-        order_by = ("name",)
-
-
-class DefaultWorkspaceUserTable(tables.Table):
-    """Class to use for default workspace tables in PRIMED."""
-
-    name = tables.Column(linkify=True, verbose_name="Workspace")
-    billing_project = tables.Column()
-    is_shared = WorkspaceSharedWithConsortiumColumn()
-
-    class Meta:
-        model = Workspace
-        fields = (
-            "name",
-            "billing_project",
             "is_shared",
         )
         order_by = ("name",)

--- a/primed/templates/snippets/data_prep_workspace_table.html
+++ b/primed/templates/snippets/data_prep_workspace_table.html
@@ -1,5 +1,7 @@
 {% load render_table from django_tables2 %}
 
+{% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
+
 <div class="my-3">
   <div class="accordion" id="accordionDataPrepWorkspace">
     <div class="accordion-item">
@@ -18,3 +20,5 @@
     </div>
   </div>
 </div>
+
+{% endif %}


### PR DESCRIPTION
- Subclass the user table to create the staff tables, and modify columns as necessary. This reduces duplication of code.
- Do not show associated data prep workspace tables to regular view users on the dbGaP and CDSA workspace detail pages.

Closes #524 