### PR TITLE
Generate input for the phenotype inventory workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 7.0.0
     hooks:
       - id: flake8
         args: ['--config=setup.cfg']

--- a/add_phenotype_inventory_input_example_data.py
+++ b/add_phenotype_inventory_input_example_data.py
@@ -1,0 +1,50 @@
+# Temporary script to create some test data.
+# Run with: python manage.py shell < add_phenotype_inventory_input_example_data.py
+
+from anvil_consortium_manager.tests.factories import (
+    ManagedGroupFactory,
+    WorkspaceGroupSharingFactory,
+)
+
+from primed.cdsa.tests.factories import CDSAWorkspaceFactory
+from primed.dbgap.tests.factories import dbGaPWorkspaceFactory
+from primed.miscellaneous_workspaces.tests.factories import OpenAccessWorkspaceFactory
+from primed.primed_anvil.tests.factories import StudyFactory
+
+# Create a dbGaP workspace.
+fhs = StudyFactory.create(short_name="FHS", full_name="Framingham Heart Study")
+workspace_dbgap = dbGaPWorkspaceFactory.create(
+    dbgap_study_accession__dbgap_phs=7,
+    dbgap_study_accession__studies=[fhs],
+    dbgap_version=33,
+    dbgap_participant_set=12,
+    dbgap_consent_code=1,
+    dbgap_consent_abbreviation="HMB",
+    workspace__name="DBGAP_FHS_v33_p12_HMB",
+)
+
+
+# Create a CDSA workspace.
+workspace_cdsa = CDSAWorkspaceFactory.create(
+    study__short_name="MESA",
+    workspace__name="CDSA_MESA_HMB",
+)
+
+# Create an open access workspace
+workspace_open_access = OpenAccessWorkspaceFactory.create(
+    workspace__name="OPEN_ACCESS_FHS",
+)
+workspace_open_access.studies.add(fhs)
+
+
+# Share workspaces with PRIMED_ALL
+primed_all = ManagedGroupFactory.create(name="PRIMED_ALL")
+WorkspaceGroupSharingFactory.create(
+    workspace=workspace_dbgap.workspace, group=primed_all
+)
+WorkspaceGroupSharingFactory.create(
+    workspace=workspace_cdsa.workspace, group=primed_all
+)
+WorkspaceGroupSharingFactory.create(
+    workspace=workspace_open_access.workspace, group=primed_all
+)

--- a/primed/primed_anvil/helpers.py
+++ b/primed/primed_anvil/helpers.py
@@ -1,6 +1,9 @@
+from itertools import groupby
+
 import pandas as pd
-from anvil_consortium_manager.models import WorkspaceGroupSharing
-from django.db.models import Exists, F, OuterRef, Value
+from anvil_consortium_manager.models import ManagedGroup, WorkspaceGroupSharing
+from django.db.models import CharField, Exists, F, OuterRef, Value
+from django.db.models.functions import Concat
 
 from primed.cdsa.models import CDSAWorkspace
 from primed.dbgap.models import dbGaPWorkspace
@@ -127,3 +130,96 @@ def get_summary_table_data():
     # Convert to a list of dictionaries for passing to the django-tables2 table.
     data = data.to_dict(orient="records")
     return data
+
+
+def get_workspaces_for_phenotype_inventory():
+    """Get input to the primed-phenotype-inventory workflow.
+
+    This function generates the input for the "workspaces" field of the primed-phenotype-inventory workflow. Only
+    workspaces that have been shared with the consortium are included.
+    See dockstore link: https://dockstore.org/workflows/github.com/UW-GAC/primed-inventory-workflows/primed_phenotype_inventory:main?tab=info
+
+    The "workspaces" field has the format:
+    {
+        "billing-project-1/workspace-1": "study1, study2",
+        "billing-project-2/workspace-2": "study3",
+        ...
+    }
+    """  # noqa: E501
+
+    # primed-all group. We will need this to determine if the workspace is shared with PRIMED_ALL.
+    primed_all = ManagedGroup.objects.get(name="PRIMED_ALL")
+
+    dbgap_workspaces = (
+        dbGaPWorkspace.objects.filter(
+            # Just those that are shared with PRIMED_ALL.
+            workspace__workspacegroupsharing__group=primed_all,
+        )
+        .annotate(
+            workspace_name=Concat(
+                F("workspace__billing_project__name"),
+                Value("/"),
+                F("workspace__name"),
+                output_field=CharField(),
+            ),
+            study_names=F("dbgap_study_accession__studies__short_name"),
+        )
+        .values(
+            # "workspace",
+            # "workspace_billing_project",
+            "workspace_name",
+            "study_names",
+        )
+    )
+
+    cdsa_workspaces = (
+        CDSAWorkspace.objects.filter(
+            # Just those that are shared with PRIMED_ALL.
+            workspace__workspacegroupsharing__group=primed_all,
+        )
+        .annotate(
+            workspace_name=Concat(
+                F("workspace__billing_project__name"),
+                Value("/"),
+                F("workspace__name"),
+                output_field=CharField(),
+            ),
+            study_names=F("study__short_name"),
+        )
+        .values(
+            "workspace_name",
+            "study_names",
+        )
+    )
+
+    open_access_workspaces = (
+        OpenAccessWorkspace.objects.filter(
+            # Just those that are shared with PRIMED_ALL.
+            workspace__workspacegroupsharing__group=primed_all,
+        )
+        .annotate(
+            workspace_name=Concat(
+                F("workspace__billing_project__name"),
+                Value("/"),
+                F("workspace__name"),
+                output_field=CharField(),
+            ),
+            study_names=F("studies__short_name"),
+        )
+        .values(
+            "workspace_name",
+            "study_names",
+        )
+    )
+
+    # Combine all querysets and process into the expected output for the AnVIL workflow.
+    workspaces = dbgap_workspaces.union(cdsa_workspaces).union(open_access_workspaces)
+
+    json = {}
+    for key, group in groupby(workspaces, lambda x: x["workspace_name"]):
+        study_names = [x["study_names"] if x["study_names"] else "" for x in group]
+        if not study_names:
+            study_names = ""
+        json[key] = ", ".join(study_names)
+
+    return json

--- a/primed/primed_anvil/helpers.py
+++ b/primed/primed_anvil/helpers.py
@@ -220,6 +220,6 @@ def get_workspaces_for_phenotype_inventory():
         study_names = [x["study_names"] if x["study_names"] else "" for x in group]
         if not study_names:
             study_names = ""
-        json[key] = ", ".join(study_names)
+        json[key] = ", ".join(sorted(study_names))
 
     return json

--- a/primed/primed_anvil/urls.py
+++ b/primed/primed_anvil/urls.py
@@ -37,9 +37,21 @@ summary_patterns = (
     "summaries",
 )
 
+utilities_patterns = (
+    [
+        path(
+            "phenotype_inventory_inputs/",
+            views.PhenotypeInventoryInputsView.as_view(),
+            name="phenotype_inventory_inputs",
+        ),
+    ],
+    "utilities",
+)
+
 urlpatterns = [
     path("studies/", include(study_patterns)),
     path("study_sites/", include(study_site_patterns)),
     path("available_data/", include(available_data_patterns)),
     path("summaries/", include(summary_patterns)),
+    path("utilities/", include(utilities_patterns)),
 ]

--- a/primed/primed_anvil/views.py
+++ b/primed/primed_anvil/views.py
@@ -1,3 +1,5 @@
+import json
+
 from anvil_consortium_manager.auth import (
     AnVILConsortiumManagerStaffEditRequired,
     AnVILConsortiumManagerStaffViewRequired,
@@ -182,4 +184,18 @@ class DataSummaryView(LoginRequiredMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         table_data = helpers.get_summary_table_data()
         context["summary_table"] = tables.DataSummaryTable(table_data)
+        return context
+
+
+class PhenotypeInventoryInputsView(
+    AnVILConsortiumManagerStaffViewRequired, TemplateView
+):
+
+    template_name = "primed_anvil/phenotype_inventory_inputs.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["workspaces_input"] = json.dumps(
+            helpers.get_workspaces_for_phenotype_inventory(), indent=2
+        )
         return context

--- a/primed/static/js/project.js
+++ b/primed/static/js/project.js
@@ -17,31 +17,3 @@ for(var i = 0; i < textInputs.length; i++){
   // Console: print the clicked <p> element
   textInputs[i].addEventListener("paste", checkPasteLength);
 }
-
-
-// Button to copy to the clipboard.
-const copyButtonLabel = "Copy Code";
-
-// use a class selector if available
-let blocks = document.querySelectorAll("pre");
-
-blocks.forEach((block) => {
-  // only add button if browser supports Clipboard API
-  if (navigator.clipboard) {
-    let button = document.createElement("button");
-
-    button.innerText = copyButtonLabel;
-    block.appendChild(button);
-
-    button.addEventListener("click", async () => {
-      await copyCode(block);
-    });
-  }
-});
-
-async function copyCode(block) {
-  let code = block.querySelector("code");
-  let text = code.innerText;
-
-  await navigator.clipboard.writeText(text);
-}

--- a/primed/static/js/project.js
+++ b/primed/static/js/project.js
@@ -17,3 +17,31 @@ for(var i = 0; i < textInputs.length; i++){
   // Console: print the clicked <p> element
   textInputs[i].addEventListener("paste", checkPasteLength);
 }
+
+
+// Button to copy to the clipboard.
+const copyButtonLabel = "Copy Code";
+
+// use a class selector if available
+let blocks = document.querySelectorAll("pre");
+
+blocks.forEach((block) => {
+  // only add button if browser supports Clipboard API
+  if (navigator.clipboard) {
+    let button = document.createElement("button");
+
+    button.innerText = copyButtonLabel;
+    block.appendChild(button);
+
+    button.addEventListener("click", async () => {
+      await copyCode(block);
+    });
+  }
+});
+
+async function copyCode(block) {
+  let code = block.querySelector("code");
+  let text = code.innerText;
+
+  await navigator.clipboard.writeText(text);
+}

--- a/primed/templates/primed_anvil/phenotype_inventory_inputs.html
+++ b/primed/templates/primed_anvil/phenotype_inventory_inputs.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% load render_table from django_tables2 %}
+
+{% block extra_navbar %}
+  {% include 'anvil_consortium_manager/navbar.html' %}
+{% endblock %}
+
+{% block content %}
+
+<h2>Phenotype inventory workflow</h2>
+
+<p>
+  This page creates the input for the "workspaces" field in the
+  <a href="https://dockstore.org/workflows/github.com/UW-GAC/primed-inventory-workflows/primed_phenotype_inventory:main?tab=info">PRIMED phenotype inventory workflow</a>.
+  Copy the text in the box below and paste it into the "workspaces" when running the workflow.
+</p>
+
+
+<div class="card">
+  <div class="card-body">
+    <h5 class="card-title">Input for the <code>workspaces</code> field</h5>
+    <p class="card-text">
+      <code>
+        <pre>{{ workspaces_input }}</pre>
+      </code>
+
+    </p>
+  </div>
+</div>
+
+
+{% endblock content %}

--- a/primed/templates/primed_anvil/phenotype_inventory_inputs.html
+++ b/primed/templates/primed_anvil/phenotype_inventory_inputs.html
@@ -20,9 +20,7 @@
   <div class="card-body">
     <h5 class="card-title">
       Input for the workspaces field
-      <span class="float-end">
-        <button class="btn btn-primary copy-button ms-5" copy-target="workspaces-input">Copy input</button>
-      </span>
+      <button class="btn btn-primary copy-button ms-3" copy-target="workspaces-input">Copy input</button>
     </h5>
     <p class="card-text">
       <pre><code id="workspaces-input">{{ workspaces_input }}</code></pre>

--- a/primed/templates/primed_anvil/phenotype_inventory_inputs.html
+++ b/primed/templates/primed_anvil/phenotype_inventory_inputs.html
@@ -18,15 +18,31 @@
 
 <div class="card">
   <div class="card-body">
-    <h5 class="card-title">Input for the <code>workspaces</code> field</h5>
+    <h5 class="card-title">Input for the workspaces field</h5>
+    <h6 class="card-subtitle mb-2 text-muted"><button class="btn btn-primary copy-button" copy-target="workspaces-input">Copy input</button></h6>
     <p class="card-text">
-      <code>
-        <pre>{{ workspaces_input }}</pre>
-      </code>
-
+      <pre><code id="workspaces-input">{{ workspaces_input }}</code></pre>
     </p>
   </div>
 </div>
 
 
 {% endblock content %}
+
+
+{% block inline_javascript %}
+<script>
+function copyOnClick(e) {
+  copy_target = e.currentTarget.getAttribute("copy-target")
+	elementToCopy = document.getElementById(copy_target)
+  textToCopy = elementToCopy.innerText
+  navigator.clipboard.writeText(textToCopy)
+  console.log("Copied text:")
+  console.log(textToCopy)
+}
+
+const button = document.querySelector(".copy-button")
+console.log(button.getAttribute("copy-target"))
+button.addEventListener("click", copyOnClick);
+</script>
+{% endblock %}

--- a/primed/templates/primed_anvil/phenotype_inventory_inputs.html
+++ b/primed/templates/primed_anvil/phenotype_inventory_inputs.html
@@ -12,7 +12,7 @@
 <p>
   This page creates the input for the "workspaces" field in the
   <a href="https://dockstore.org/workflows/github.com/UW-GAC/primed-inventory-workflows/primed_phenotype_inventory:main?tab=info">PRIMED phenotype inventory workflow</a>.
-  Copy the text in the box below and paste it into the "workspaces" when running the workflow.
+  Copy the text in the box below and paste it into the "workspaces" field when running the workflow on AnVIL.
 </p>
 
 

--- a/primed/templates/primed_anvil/phenotype_inventory_inputs.html
+++ b/primed/templates/primed_anvil/phenotype_inventory_inputs.html
@@ -18,8 +18,12 @@
 
 <div class="card">
   <div class="card-body">
-    <h5 class="card-title">Input for the workspaces field</h5>
-    <h6 class="card-subtitle mb-2 text-muted"><button class="btn btn-primary copy-button" copy-target="workspaces-input">Copy input</button></h6>
+    <h5 class="card-title">
+      Input for the workspaces field
+      <span class="float-end">
+        <button class="btn btn-primary copy-button ms-5" copy-target="workspaces-input">Copy input</button>
+      </span>
+    </h5>
     <p class="card-text">
       <pre><code id="workspaces-input">{{ workspaces_input }}</code></pre>
     </p>

--- a/primed/templates/primed_anvil/phenotype_inventory_inputs.html
+++ b/primed/templates/primed_anvil/phenotype_inventory_inputs.html
@@ -36,9 +36,16 @@ function copyOnClick(e) {
   copy_target = e.currentTarget.getAttribute("copy-target")
 	elementToCopy = document.getElementById(copy_target)
   textToCopy = elementToCopy.innerText
-  navigator.clipboard.writeText(textToCopy)
+  var copied = false
+
   console.log("Copied text:")
   console.log(textToCopy)
+
+  navigator.clipboard.writeText(textToCopy)
+
+  e.currentTarget.innerText = "Copied!";
+  e.currentTarget.className += " disabled"
+
 }
 
 const button = document.querySelector(".copy-button")


### PR DESCRIPTION
This PR is part of a bigger project in PRIMED to create a phenotype inventory in AnVIL. A workflow already exists to create the inventory using a list of workspaces and associated studies (see https://github.com/UW-GAC/primed-inventory-workflows), and this PR generates the input for that workflow.

- Add a helper function that prepares the input for the workflow.
- Add a view to display the input and allow the user to copy it to the clipboard.