### PR TITLE
Use pre-commit.ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,27 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  linter:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Checkout Code Repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-          cache: pip
-          cache-dependency-path: |
-            requirements/requirements.txt
-            requirements/test-requirements.txt
-
-      # Run all pre-commit hooks on all the files.
-      # Getting only staged files can be tricky in case a new PR is opened
-      # since the action is run on a branch in detached head state
-      - name: Install and Run Pre-commit
-        uses: pre-commit/action@v3.0.1
 
   pytest-mariadb:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [![Black code style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/UW-GAC/gregor-django/main.svg)](https://results.pre-commit.ci/latest/github/UW-GAC/gregor-django/main)
+
 [![image](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
 
 [![Built with Cookiecutter Django](https://img.shields.io/badge/built%20with-Cookiecutter%20Django-ff69b4.svg?logo=cookiecutter)](https://github.com/pydanny/cookiecutter-django/)


### PR DESCRIPTION
The pre-commit action recommends using pre-commit.ci instead.

Note: before starting this PR, I gave pre-commit ci access to this repo starting at this page:
https://results.pre-commit.ci/