### PR TITLE
Pin django-stubs to a matching django version

### DIFF
--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -7,7 +7,7 @@ ipdb  # https://github.com/gotcha/ipdb
 # Type checking
 # ------------------------------------------------------------------------------
 mypy  # https://github.com/python/mypy
-django-stubs  # https://github.com/typeddjango/django-stubs
+django-stubs>=4.2,<5.0  # https://github.com/typeddjango/django-stubs
 types-requests
 
 # Documentation


### PR DESCRIPTION
dependabot tried to update to django-stubs 5.0, but we are running django 4.2.