### PR TITLE
Run parallelized pytest tests by default

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ds=config.settings.test --reuse-db
+addopts = --ds=config.settings.test --reuse-db -n auto
 python_files = tests.py test_*.py
 filterwarnings =
     # Convert all warnings to errors.


### PR DESCRIPTION
Add the `-n auto` setting to pytest `addopts` in pytest.ini file