### PR TITLE
Add a CI step to optionally recompile requirements files with pip-sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
         mariadb-version: ["10.4"]
         include:
           # Not sure yet how best to include CI for a newer python version with the pip-tools workflow.
-          - python-version: 3.11  # Possible future version.
+          - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
             pip-recompile: true
-          - python-version: 3.11  # Possible future version.
+          - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
             pip-recompile: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,11 @@ jobs:
           - python-version: 3.8  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
+            pip-recompile: true
           - python-version: 3.8  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
+            pip-recompile: true
 
     name: "py${{ matrix.python-version }}-${{ matrix.backend }}-${{ matrix.mariadb-version }}"
 
@@ -77,6 +79,14 @@ jobs:
 
       - name: Install piptools
         run: python -m pip install pip-tools
+
+      - name: Recompile pip files if requested
+        if: matrix.pip-recompile
+        run: |
+          pip-compile requirements/requirements.in
+          pip-compile requirements/test-requirements.in
+          # Print out changes.
+          git diff
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
         mariadb-version: ["10.4"]
         include:
           # Not sure yet how best to include CI for a newer python version with the pip-tools workflow.
-          - python-version: 3.8  # Possible future version.
+          - python-version: 3.11  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
             pip-recompile: true
-          - python-version: 3.8  # Possible future version.
+          - python-version: 3.11  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
             pip-recompile: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,18 @@ jobs:
             requirements/requirements.txt
             requirements/test-requirements.txt
 
+      - name: Ensure pip is installed
+        run: |
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
+          # Upgrade setup tools
+          python -m pip install --upgrade setuptools
+
+      - name: Install piptools
+        run: python -m pip install pip-tools
+
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pip-tools
           pip-sync requirements/requirements.txt requirements/test-requirements.txt
 
       - name: Collect staticfiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
         mariadb-version: ["10.4"]
         include:
           # Not sure yet how best to include CI for a newer python version with the pip-tools workflow.
-          - python-version: 3.12  # Possible future version.
+          - python-version: 3.11  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
             pip-recompile: true
-          - python-version: 3.12  # Possible future version.
+          - python-version: 3.11  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
             pip-recompile: true


### PR DESCRIPTION
* Add a step to the CI that (optionally) reruns pip-compile on the requirements.in files
* Add a pip-recompile setting to the matrix definitions that can be used to toggle whether this step should run.

The pip-recompile setting can be set to true when we want to test future versions of python compared to what is running on the live servers.