### PR TITLE
Switch future CI to use python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,11 @@ jobs:
         backend: ["sqlite", "mariadb"]
         mariadb-version: ["10.4"]
         include:
-          # Not sure yet how best to include CI for a newer python version with the pip-tools workflow.
-          - python-version: 3.11  # Possible future version.
+          - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.5"
             pip-recompile: true
-          - python-version: 3.11  # Possible future version.
+          - python-version: 3.12  # Possible future version.
             backend: "mariadb"
             mariadb-version: "10.11"
             pip-recompile: true

--- a/primed/drupal_oauth_provider/tests.py
+++ b/primed/drupal_oauth_provider/tests.py
@@ -104,7 +104,7 @@ class CustomProviderTests(OAuth2TestsMixin, TestCase):
     # This login response mimics drupals in that it contains a set of scopes
     # and the uid which has the name sub
     def get_login_response_json(self, with_refresh_token=True):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         app = get_adapter().get_app(request=None, provider=self.provider_id)
         allowed_audience = app.client_id
         id_token = sign_id_token(

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,4 @@ filterwarnings =
     ignore:pkg_resources is deprecated as an API.:DeprecationWarning:model_utils
     # Warning raised by pkg_resources via model_utils. ??
     ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning:pkg_resources
+    ignore:'pkgutil.find_loader' is deprecated and slated for removal in Python 3.14:DeprecationWarning:pkg_resources

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,4 +8,4 @@ filterwarnings =
     ignore:pkg_resources is deprecated as an API.:DeprecationWarning:model_utils
     # Warning raised by pkg_resources via model_utils. ??
     ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning:pkg_resources
-    ignore:'pkgutil.find_loader' is deprecated and slated for removal in Python 3.14:DeprecationWarning:pkg_resources
+    ignore:'pkgutil.find_loader' is deprecated and slated for removal in Python 3.14:DeprecationWarning

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -33,7 +33,7 @@ django-dbbackup # https://github.com/jazzband/django-dbbackup
 django-extensions  # https://github.com/django-extensions/django-extensions
 
 # anvil_consortium_manager
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.22
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@a6f69539a5f01b45d68ee8a44b275d38b97ea8ae
 
 # Simple history - model history tracking
 django-simple-history

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -33,7 +33,7 @@ django-dbbackup # https://github.com/jazzband/django-dbbackup
 django-extensions  # https://github.com/django-extensions/django-extensions
 
 # anvil_consortium_manager
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@a6f69539a5f01b45d68ee8a44b275d38b97ea8ae
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.22.1
 
 # Simple history - model history tracking
 django-simple-history

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -62,7 +62,7 @@ django==4.2.13
     #   django-tables2
 django-allauth==0.54.0
     # via -r requirements/requirements.in
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@va6f69539a5f01b45d68ee8a44b275d38b97ea8ae
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@a6f69539a5f01b45d68ee8a44b275d38b97ea8ae
     # via -r requirements/requirements.in
 django-autocomplete-light==3.11.0
     # via django-anvil-consortium-manager

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -62,7 +62,7 @@ django==4.2.13
     #   django-tables2
 django-allauth==0.54.0
     # via -r requirements/requirements.in
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.22
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@va6f69539a5f01b45d68ee8a44b275d38b97ea8ae
     # via -r requirements/requirements.in
 django-autocomplete-light==3.11.0
     # via django-anvil-consortium-manager

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -62,7 +62,7 @@ django==4.2.13
     #   django-tables2
 django-allauth==0.54.0
     # via -r requirements/requirements.in
-django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@a6f69539a5f01b45d68ee8a44b275d38b97ea8ae
+django-anvil-consortium-manager @ git+https://github.com/UW-GAC/django-anvil-consortium-manager.git@v0.22.1
     # via -r requirements/requirements.in
 django-autocomplete-light==3.11.0
     # via django-anvil-consortium-manager


### PR DESCRIPTION
- Use python 3.12 in future CI
- Fix a deprecation warning in `drupal_oauth_provider`