### PR TITLE
Remove debugging print statement in template

### DIFF
--- a/primed/templates/users/user_detail.html
+++ b/primed/templates/users/user_detail.html
@@ -155,5 +155,4 @@
 
 </div>
 
-<p>{{ signed_agreements }}</p>
 {% endblock content %}


### PR DESCRIPTION
The user detail template was still printing out the signed agreements from when I was trying to debug something. Remove that statement.