### PR TITLE
Fix failing test for mysql

### DIFF
--- a/primed/dbgap/tests/test_forms.py
+++ b/primed/dbgap/tests/test_forms.py
@@ -857,7 +857,9 @@ class dbGaPDataAccessSnapshotFormTest(TestCase):
     def test_dbgap_project_id_does_not_match(self):
         """Form is not valid when the dbgap_project_id does not match."""
         form_data = {
-            "dbgap_dar_data": json.dumps([factories.dbGaPJSONProjectFactory(Project_id=2)]),
+            "dbgap_dar_data": json.dumps(
+                [factories.dbGaPJSONProjectFactory(Project_id=self.dbgap_application.dbgap_project_id + 1)]
+            ),
             "dbgap_application": self.dbgap_application,
         }
         form = self.form_class(data=form_data)


### PR DESCRIPTION
test_dbgap_project_id_does_not_match was failing only in mysql likely because in mysql tests, the pk field does not reset to 1 for each test. A (new) previous test likely created a dbGaP application, so when this test had the project_id hard-coded, it failed. Now, set the dbGaP application project_id using the application that the test created in the setup method.