### PR TITLE
Fix badge for consortium members with data access

### DIFF
--- a/primed/templates/primed_anvil/studysite_detail.html
+++ b/primed/templates/primed_anvil/studysite_detail.html
@@ -60,7 +60,7 @@
         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMembersOne" aria-expanded="false" aria-controls="collapseMembersOne">
           <span class="fa-solid fa-cloud-arrow-down mx-2"></span>
           View consortium members with data access
-          <span class="badge mx-2 bg-secondary pill"> {{ tables.1.rows|length }}</span>
+          <span class="badge mx-2 bg-secondary pill"> {{ tables.3.rows|length }}</span>
         </button>
       </h2>
       <div id="collapseMembersOne" class="accordion-collapse collapse" aria-labelledby="headingMembersOne" data-bs-parent="#accordionMembers">


### PR DESCRIPTION
The badge next to the consortium members with data access is using the wrong table; use the correct table to calculate the count to show in the badge.