### PR TITLE
Better behavior for inactive users

### DIFF
--- a/primed/templates/base.html
+++ b/primed/templates/base.html
@@ -28,8 +28,8 @@
     {# Placed at the top of the document so pages load faster with defer #}
     {% block javascript %}
       <!-- Bootstrap JS and its dependencies-->
-      <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
       <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+      <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
       <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
 
       <!-- Your stuff: Third-party javascript libraries go here -->
@@ -119,9 +119,10 @@
       {% endif %}
 
       {% if request.user.is_authenticated and not request.user.account %}
-      <div class="alert alert-warning" role="alert">
+      <div class="alert alert-warning alert-dismissible fade show" role="alert">
         <i class="bi bi-exclamation-triangle-fill me-1"></i>
         You must <a href="{% url 'anvil_consortium_manager:accounts:link' %}">link your AnVIL account</a> before you can access any data on AnVIL.
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>
     {% endif %}
 

--- a/primed/templates/users/user_detail.html
+++ b/primed/templates/users/user_detail.html
@@ -6,6 +6,15 @@
 {% block content %}
 <div class="container">
 
+  {% if not object.is_active %}
+
+    <p class='alert alert-secondary mt-3'>
+      <i class="bi bi-exclamation-triangle-fill"></i>
+      This user is inactive.
+    </p>
+
+    {% endif %}
+
   <div class="row row-cols-1 rows-cols-sm-2 row-cols-md-2 g-2 mt-3">
     <div class="col">
       <div class='card card-shadow-sm'>

--- a/primed/templates/users/user_detail.html
+++ b/primed/templates/users/user_detail.html
@@ -74,6 +74,12 @@
                 {% else %}
                 {{ object.account.email }}
                 {% endif %}
+                {% if not object.account.status %}
+                  <p class='alert alert-secondary mt-3'>
+                    <i class="bi bi-exclamation-triangle-fill"></i>
+                    This account is inactive.
+                  </p>
+                {% endif %}
               </li>
               {% if object.account.verified_email_entry %}
               <li class='list-group-item'>

--- a/primed/templates/users/user_detail.html
+++ b/primed/templates/users/user_detail.html
@@ -8,7 +8,7 @@
 
   {% if not object.is_active %}
 
-    <p class='alert alert-secondary mt-3'>
+    <p class='alert alert-danger mt-3'>
       <i class="bi bi-exclamation-triangle-fill"></i>
       This user is inactive.
     </p>
@@ -66,6 +66,14 @@
         <div class='card-body'>
           {% if object.account %}
             <p><i class="bi bi-check-circle-fill text-success"></i> Profile has a linked AnVIL account established</p>
+
+            {% if not object.account.status %}
+              <p class='alert alert-danger mt-3'>
+                <i class="bi bi-exclamation-triangle-fill"></i>
+                This account is inactive.
+              </p>
+              {% endif %}
+
             <ul class='list-group'>
               <li class='list-group-item'>
                 <h5>Account Email</h5>
@@ -73,12 +81,6 @@
                 <a href="{{ object.account.get_absolute_url }}">{{ object.account.email }}</a>
                 {% else %}
                 {{ object.account.email }}
-                {% endif %}
-                {% if not object.account.status %}
-                  <p class='alert alert-secondary mt-3'>
-                    <i class="bi bi-exclamation-triangle-fill"></i>
-                    This account is inactive.
-                  </p>
                 {% endif %}
               </li>
               {% if object.account.verified_email_entry %}

--- a/primed/users/forms.py
+++ b/primed/users/forms.py
@@ -24,7 +24,7 @@ class UserLookupForm(Bootstrap5MediaFormMixin, forms.Form):
     """Form for the user lookup"""
 
     user = forms.ModelChoiceField(
-        queryset=User.objects.all(),
+        queryset=User.objects.filter(is_active=True),
         widget=autocomplete.ModelSelect2(
             url="users:autocomplete",
             attrs={"data-theme": "bootstrap-5"},

--- a/primed/users/tests/test_forms.py
+++ b/primed/users/tests/test_forms.py
@@ -63,3 +63,16 @@ class UserLookupFormTest(TestCase):
         self.assertIn("user", form.errors)
         self.assertEqual(len(form.errors["user"]), 1)
         self.assertIn("required", form.errors["user"][0])
+
+    def test_inactive_user(self):
+        """Form is invalid when user is inactive."""
+        user_obj = UserFactory.create(is_active=False)
+        form_data = {
+            "user": user_obj,
+        }
+        form = self.form_class(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(len(form.errors), 1)
+        self.assertIn("user", form.errors)
+        self.assertEqual(len(form.errors["user"]), 1)
+        self.assertIn("valid choice", form.errors["user"][0])

--- a/primed/users/tests/test_views.py
+++ b/primed/users/tests/test_views.py
@@ -810,3 +810,21 @@ class UserLookup(TestCase):
         self.assertIn("user", form.errors.keys())
         self.assertEqual(len(form.errors["user"]), 1)
         self.assertIn("required", form.errors["user"][0])
+
+    def test_invalid_inactive_user(self):
+        """Form is invalid with an inactive user."""
+        object = UserFactory.create(
+            username="user1",
+            password="passwd",
+            email="user1@example.com",
+            is_active=False,
+        )
+        self.client.force_login(self.user)
+        response = self.client.post(self.get_url(), {"user": object.pk})
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertEqual(len(form.errors), 1)
+        self.assertIn("user", form.errors)
+        self.assertEqual(len(form.errors["user"]), 1)
+        self.assertIn("valid choice", form.errors["user"][0])

--- a/primed/users/tests/test_views.py
+++ b/primed/users/tests/test_views.py
@@ -723,6 +723,17 @@ class UserAutocompleteTest(TestCase):
         view.setup(request)
         self.assertEqual(view.get_selected_result_label(instance), "First Last (foo@bar.com)")
 
+    def test_excludes_inactive_users(self):
+        """Queryset excludes excludes inactive users."""
+        UserFactory.create(is_active=False)
+        request = self.factory.get(self.get_url())
+        request.user = self.user
+        response = self.get_view()(request)
+        returned_ids = [int(x["id"]) for x in json.loads(response.content.decode("utf-8"))["results"]]
+        # Only test user.
+        self.assertEqual(len(returned_ids), 1)
+        self.assertEqual(returned_ids, [self.user.pk])
+
 
 class UserLookup(TestCase):
     """Test for UserLookup view"""

--- a/primed/users/tests/test_views.py
+++ b/primed/users/tests/test_views.py
@@ -589,6 +589,24 @@ class UserDetailTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "This user is inactive.")
 
+    def test_inactive_anvil_account_alert_is_inactive(self):
+        """Alert is shown when AnVIL account is inactive."""
+        account = AccountFactory.create(email="foo@bar.com", user=self.user, verified=True)
+        account.status = account.INACTIVE_STATUS
+        account.save()
+        self.client.force_login(self.user)
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "This account is inactive.")
+
+    def test_inactive_anvil_account_alert_is_active(self):
+        """Alert is not shown when AnVIL account is active."""
+        AccountFactory.create(email="foo@bar.com", user=self.user, verified=True)
+        self.client.force_login(self.user)
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "This account is inactive.")
+
 
 class UserAutocompleteTest(TestCase):
     def setUp(self):

--- a/primed/users/tests/test_views.py
+++ b/primed/users/tests/test_views.py
@@ -574,6 +574,21 @@ class UserDetailTest(TestCase):
         self.assertIn(agreement_1.signed_agreement, response.context["signed_agreements"])
         self.assertIn(agreement_2.signed_agreement, response.context["signed_agreements"])
 
+    def test_inactive_user_inactive_message(self):
+        """Inactive user alert is shown for an inactive user."""
+        user = UserFactory.create(is_active=False)
+        self.client.force_login(self.user)
+        response = self.client.get(user.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "This user is inactive.")
+
+    def test_active_user_no_inactive_message(self):
+        """Inactive user alert is not shown for an active user."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "This user is inactive.")
+
 
 class UserAutocompleteTest(TestCase):
     def setUp(self):

--- a/primed/users/views.py
+++ b/primed/users/views.py
@@ -67,7 +67,9 @@ class UserAutocompleteView(LoginRequiredMixin, autocomplete.Select2QuerySetView)
 
     def get_queryset(self):
         """Filter to users matching the query."""
-        qs = User.objects.all().order_by("username")
+        qs = User.objects.filter(
+            is_active=True,
+        ).order_by("username")
 
         if self.q:
             # Filter to users whose name or email matches the query.


### PR DESCRIPTION
- Show alerts on the user profile page if 1) the user is inactive or 2) the user's linked account is inactive
- Hide inactive users in the user autocomplete view
- Do not allow user lookups for inactive users (but you can still manually navigate to their profile page)

and a couple other misc updates:
- make the alert about linking your account dismissible