### PR TITLE
Fix bug where only a single study is shown for a workspace linked to multiple studies

### DIFF
--- a/add_inventory_input_example_data.py
+++ b/add_inventory_input_example_data.py
@@ -1,5 +1,5 @@
 # Temporary script to create some test data.
-# Run with: python manage.py shell < add_phenotype_inventory_input_example_data.py
+# Run with: python manage.py shell < add_inventory_input_example_data.py
 
 from anvil_consortium_manager.tests.factories import (
     ManagedGroupFactory,

--- a/primed/primed_anvil/helpers.py
+++ b/primed/primed_anvil/helpers.py
@@ -130,12 +130,12 @@ def get_summary_table_data():
     return data
 
 
-def get_workspaces_for_phenotype_inventory():
+def get_workspaces_for_inventory():
     """Get input to the primed-phenotype-inventory workflow.
 
     This function generates the input for the "workspaces" field of the primed-phenotype-inventory workflow. Only
     workspaces that have been shared with the consortium are included.
-    See dockstore link: https://dockstore.org/workflows/github.com/UW-GAC/primed-inventory-workflows/primed_phenotype_inventory:main?tab=info
+    See dockstore link: https://dockstore.org/workflows/github.com/UW-GAC/primed-inventory-workflows/primed_inventory:main?tab=info
 
     The "workspaces" field has the format:
     {

--- a/primed/primed_anvil/helpers.py
+++ b/primed/primed_anvil/helpers.py
@@ -212,6 +212,8 @@ def get_workspaces_for_phenotype_inventory():
 
     # Combine all querysets and process into the expected output for the AnVIL workflow.
     workspaces = dbgap_workspaces.union(cdsa_workspaces).union(open_access_workspaces)
+    # Sort by workspace_name so that itertools.groupby works as expected.
+    workspaces = sorted(workspaces, key=lambda x: x["workspace_name"])
     json = {}
     for key, group in groupby(workspaces, lambda x: x["workspace_name"]):
         study_names = [x["study_names"] if x["study_names"] else "" for x in group]

--- a/primed/primed_anvil/helpers.py
+++ b/primed/primed_anvil/helpers.py
@@ -212,7 +212,6 @@ def get_workspaces_for_phenotype_inventory():
 
     # Combine all querysets and process into the expected output for the AnVIL workflow.
     workspaces = dbgap_workspaces.union(cdsa_workspaces).union(open_access_workspaces)
-
     json = {}
     for key, group in groupby(workspaces, lambda x: x["workspace_name"]):
         study_names = [x["study_names"] if x["study_names"] else "" for x in group]

--- a/primed/primed_anvil/tests/test_helpers.py
+++ b/primed/primed_anvil/tests/test_helpers.py
@@ -860,3 +860,72 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         self.assertEqual(res["test-a/test-a_c2"], "TEST_1")
         self.assertEqual(res["test-a/test-a_c3"], "TEST_1")
         self.assertEqual(res["test-a/test-a_c4"], "TEST_1")
+
+    def test_order_dbgap(self):
+        """dbGaPWorkspaces are ordered by billing project in results."""
+        workspace_1 = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp-2",
+            workspace__name="test-ws-3",
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_1.workspace, group=self.primed_all_group)
+        workspace_2 = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp-2",
+            workspace__name="test-ws-1",
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_2.workspace, group=self.primed_all_group)
+        workspace_3 = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp-1",
+            workspace__name="test-ws-2",
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_3.workspace, group=self.primed_all_group)
+        res = helpers.get_workspaces_for_phenotype_inventory()
+        self.assertEqual(len(res), 3)
+        self.assertEqual(list(res)[0], "test-bp-1/test-ws-2")
+        self.assertEqual(list(res)[1], "test-bp-2/test-ws-1")
+        self.assertEqual(list(res)[2], "test-bp-2/test-ws-3")
+
+    def test_order_cdsa(self):
+        """CDSAWorkspaces are ordered by billing project in results."""
+        workspace_1 = CDSAWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp-2",
+            workspace__name="test-ws-3",
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_1.workspace, group=self.primed_all_group)
+        workspace_2 = CDSAWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp-2",
+            workspace__name="test-ws-1",
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_2.workspace, group=self.primed_all_group)
+        workspace_3 = CDSAWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp-1",
+            workspace__name="test-ws-2",
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_3.workspace, group=self.primed_all_group)
+        res = helpers.get_workspaces_for_phenotype_inventory()
+        self.assertEqual(len(res), 3)
+        self.assertEqual(list(res)[0], "test-bp-1/test-ws-2")
+        self.assertEqual(list(res)[1], "test-bp-2/test-ws-1")
+        self.assertEqual(list(res)[2], "test-bp-2/test-ws-3")
+
+    def test_order_open_access(self):
+        """OpenAccessWorkspaces are ordered by billing project in results."""
+        workspace_1 = OpenAccessWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp-2",
+            workspace__name="test-ws-3",
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_1.workspace, group=self.primed_all_group)
+        workspace_2 = OpenAccessWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp-2",
+            workspace__name="test-ws-1",
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_2.workspace, group=self.primed_all_group)
+        workspace_3 = OpenAccessWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp-1",
+            workspace__name="test-ws-2",
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_3.workspace, group=self.primed_all_group)
+        res = helpers.get_workspaces_for_phenotype_inventory()
+        self.assertEqual(len(res), 3)
+        self.assertEqual(list(res)[0], "test-bp-1/test-ws-2")
+        self.assertEqual(list(res)[1], "test-bp-2/test-ws-1")
+        self.assertEqual(list(res)[2], "test-bp-2/test-ws-3")

--- a/primed/primed_anvil/tests/test_helpers.py
+++ b/primed/primed_anvil/tests/test_helpers.py
@@ -541,7 +541,7 @@ class GetSummaryTableDataTest(TestCase):
 
 
 class GetWorkspacesForPhenotypeInventoryTest(TestCase):
-    """Tests for the helpers.get_workspaces_for_phenotype_inventory method."""
+    """Tests for the helpers.get_workspaces_for_inventory method."""
 
     def setUp(self):
         """Set up the test case."""
@@ -550,18 +550,18 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         self.primed_all_group = ManagedGroupFactory.create(name="PRIMED_ALL")
 
     def test_no_workspaces(self):
-        """get_workspaces_for_phenotype_inventory with no workspaces."""
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        """get_workspaces_for_inventory with no workspaces."""
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(res, {})
 
     def test_one_dbgap_workspace_not_shared(self):
-        """get_workspaces_for_phenotype_inventory with one dbGaP workspace."""
+        """get_workspaces_for_inventory with one dbGaP workspace."""
         dbGaPWorkspaceFactory.create()
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(res, {})
 
     def test_one_dbgap_workspace_shared_one_study(self):
-        """get_workspaces_for_phenotype_inventory with one dbGaP workspace."""
+        """get_workspaces_for_inventory with one dbGaP workspace."""
         study = StudyFactory.create(short_name="TEST")
         workspace = dbGaPWorkspaceFactory.create(
             workspace__billing_project__name="test-bp",
@@ -569,13 +569,13 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
             dbgap_study_accession__studies=[study],
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 1)
         self.assertIn("test-bp/test-ws", res)
         self.assertEqual(res["test-bp/test-ws"], "TEST")
 
     def test_one_dbgap_workspace_shared_two_studies(self):
-        """get_workspaces_for_phenotype_inventory with one dbGaP workspace."""
+        """get_workspaces_for_inventory with one dbGaP workspace."""
         study_1 = StudyFactory.create(short_name="TEST_2")
         study_2 = StudyFactory.create(short_name="TEST_1")
         study_accession = dbGaPStudyAccessionFactory.create(studies=[study_1, study_2])
@@ -585,13 +585,13 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
             dbgap_study_accession=study_accession,
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 1)
         self.assertIn("test-bp/test-ws", res)
         self.assertEqual(res["test-bp/test-ws"], "TEST_1, TEST_2")
 
     def test_two_dbgap_workspaces(self):
-        """get_workspaces_for_phenotype_inventory with two dbGaP workspaces."""
+        """get_workspaces_for_inventory with two dbGaP workspaces."""
         study_1 = StudyFactory.create(short_name="TEST 1")
         workspace_1 = dbGaPWorkspaceFactory.create(
             workspace__billing_project__name="test-bp-1",
@@ -606,7 +606,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
             dbgap_study_accession__studies=[study_2],
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_2.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 2)
         self.assertIn("test-bp-1/test-ws-1", res)
         self.assertEqual(res["test-bp-1/test-ws-1"], "TEST 1")
@@ -614,13 +614,13 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         self.assertEqual(res["test-bp-2/test-ws-2"], "TEST 2")
 
     def test_one_cdsa_workspace_not_shared(self):
-        """get_workspaces_for_phenotype_inventory with one CDSA workspace."""
+        """get_workspaces_for_inventory with one CDSA workspace."""
         CDSAWorkspaceFactory.create()
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(res, {})
 
     def test_one_cdsa_workspace_shared_one_study(self):
-        """get_workspaces_for_phenotype_inventory with one CDSA workspace."""
+        """get_workspaces_for_inventory with one CDSA workspace."""
         study = StudyFactory.create(short_name="TEST")
         workspace = CDSAWorkspaceFactory.create(
             workspace__billing_project__name="test-bp",
@@ -628,13 +628,13 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
             study=study,
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 1)
         self.assertIn("test-bp/test-ws", res)
         self.assertEqual(res["test-bp/test-ws"], "TEST")
 
     def test_two_cdsa_workspaces(self):
-        """get_workspaces_for_phenotype_inventory with two CDSA workspaces."""
+        """get_workspaces_for_inventory with two CDSA workspaces."""
         study_1 = StudyFactory.create(short_name="TEST 1")
         workspace_1 = CDSAWorkspaceFactory.create(
             workspace__billing_project__name="test-bp-1",
@@ -649,7 +649,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
             study=study_2,
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_2.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 2)
         self.assertIn("test-bp-1/test-ws-1", res)
         self.assertEqual(res["test-bp-1/test-ws-1"], "TEST 1")
@@ -657,25 +657,25 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         self.assertEqual(res["test-bp-2/test-ws-2"], "TEST 2")
 
     def test_one_open_access_workspace_not_shared(self):
-        """get_workspaces_for_phenotype_inventory with one dbGaP workspace."""
+        """get_workspaces_for_inventory with one dbGaP workspace."""
         OpenAccessWorkspaceFactory.create()
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(res, {})
 
     def test_one_open_access_workspace_shared_no_study(self):
-        """get_workspaces_for_phenotype_inventory with one Open access workspace."""
+        """get_workspaces_for_inventory with one Open access workspace."""
         workspace = OpenAccessWorkspaceFactory.create(
             workspace__billing_project__name="test-bp",
             workspace__name="test-ws",
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 1)
         self.assertIn("test-bp/test-ws", res)
         self.assertEqual(res["test-bp/test-ws"], "")
 
     def test_one_open_access_workspace_shared_one_study(self):
-        """get_workspaces_for_phenotype_inventory with one Open access workspace."""
+        """get_workspaces_for_inventory with one Open access workspace."""
         study = StudyFactory.create(short_name="TEST")
         workspace = OpenAccessWorkspaceFactory.create(
             workspace__billing_project__name="test-bp",
@@ -683,13 +683,13 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         )
         workspace.studies.add(study)
         WorkspaceGroupSharingFactory.create(workspace=workspace.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 1)
         self.assertIn("test-bp/test-ws", res)
         self.assertEqual(res["test-bp/test-ws"], "TEST")
 
     def test_one_open_access_workspace_shared_two_studies(self):
-        """get_workspaces_for_phenotype_inventory with one Open access workspace."""
+        """get_workspaces_for_inventory with one Open access workspace."""
         study_1 = StudyFactory.create(short_name="TEST_2")
         study_2 = StudyFactory.create(short_name="TEST_1")
         workspace = OpenAccessWorkspaceFactory.create(
@@ -698,13 +698,13 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         )
         workspace.studies.add(study_1, study_2)
         WorkspaceGroupSharingFactory.create(workspace=workspace.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 1)
         self.assertIn("test-bp/test-ws", res)
         self.assertEqual(res["test-bp/test-ws"], "TEST_1, TEST_2")
 
     def test_two_open_access_workspaces(self):
-        """get_workspaces_for_phenotype_inventory with two Open access workspace."""
+        """get_workspaces_for_inventory with two Open access workspace."""
         workspace_1 = OpenAccessWorkspaceFactory.create(
             workspace__billing_project__name="test-bp-1",
             workspace__name="test-ws-1",
@@ -717,7 +717,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         )
         workspace_2.studies.add(study_2)
         WorkspaceGroupSharingFactory.create(workspace=workspace_2.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 2)
         self.assertIn("test-bp-1/test-ws-1", res)
         self.assertEqual(res["test-bp-1/test-ws-1"], "")
@@ -747,7 +747,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         )
         workspace.studies.add(study)
         WorkspaceGroupSharingFactory.create(workspace=workspace.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 3)
         self.assertIn("test-bp-dbgap/test-ws-dbgap", res)
         self.assertEqual(res["test-bp-dbgap/test-ws-dbgap"], "TEST")
@@ -781,7 +781,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         )
         workspace.studies.add(study_3)
         WorkspaceGroupSharingFactory.create(workspace=workspace.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 3)
         self.assertIn("test-bp-dbgap/test-ws-dbgap", res)
         self.assertEqual(res["test-bp-dbgap/test-ws-dbgap"], "TEST 1")
@@ -850,7 +850,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
             dbgap_study_accession=study_accession_1,
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_1_d.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 8)
         self.assertEqual(res["test-b/test-a-b_c1"], "TEST_1, TEST_2")
         self.assertEqual(res["test-b/test-a-b_c2"], "TEST_1, TEST_2")
@@ -878,7 +878,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
             workspace__name="test-ws-2",
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_3.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 3)
         self.assertEqual(list(res)[0], "test-bp-1/test-ws-2")
         self.assertEqual(list(res)[1], "test-bp-2/test-ws-1")
@@ -901,7 +901,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
             workspace__name="test-ws-2",
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_3.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 3)
         self.assertEqual(list(res)[0], "test-bp-1/test-ws-2")
         self.assertEqual(list(res)[1], "test-bp-2/test-ws-1")
@@ -924,7 +924,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
             workspace__name="test-ws-2",
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_3.workspace, group=self.primed_all_group)
-        res = helpers.get_workspaces_for_phenotype_inventory()
+        res = helpers.get_workspaces_for_inventory()
         self.assertEqual(len(res), 3)
         self.assertEqual(list(res)[0], "test-bp-1/test-ws-2")
         self.assertEqual(list(res)[1], "test-bp-2/test-ws-1")

--- a/primed/primed_anvil/tests/test_helpers.py
+++ b/primed/primed_anvil/tests/test_helpers.py
@@ -794,24 +794,34 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         """Studies are grouped even if workspaces are listed non-consecutively."""
         # This is attempting to capture an issue where:
         # 1) there are multiple workspaces for the same set of studies
-        study_1 = StudyFactory.create(short_name="TEST_2")
-        study_2 = StudyFactory.create(short_name="TEST_1")
-        study_accession = dbGaPStudyAccessionFactory.create(studies=[study_1, study_2])
+        study_1 = StudyFactory.create(short_name="Foo")
+        study_2 = StudyFactory.create(short_name="Bar")
+        # study_3 = StudyFactory.create(short_name="Test")
+        study_accession_1 = dbGaPStudyAccessionFactory.create(studies=[study_1, study_2])
+        study_accession_2 = dbGaPStudyAccessionFactory.create(studies=[study_2])
         workspace_1 = dbGaPWorkspaceFactory.create(
             workspace__billing_project__name="test-bp",
             workspace__name="test-ws-1",
-            dbgap_study_accession=study_accession,
+            dbgap_study_accession=study_accession_1,
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_1.workspace, group=self.primed_all_group)
         workspace_2 = dbGaPWorkspaceFactory.create(
             workspace__billing_project__name="test-bp",
             workspace__name="test-ws-2",
-            dbgap_study_accession=study_accession,
+            dbgap_study_accession=study_accession_1,
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_2.workspace, group=self.primed_all_group)
+        workspace_3 = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-bp",
+            workspace__name="test-ws-3",
+            dbgap_study_accession=study_accession_2,
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_3.workspace, group=self.primed_all_group)
         res = helpers.get_workspaces_for_phenotype_inventory()
-        self.assertEqual(len(res), 2)
+        self.assertEqual(len(res), 3)
         self.assertIn("test-bp/test-ws-1", res)
-        self.assertEqual(res["test-bp/test-ws-1"], "TEST_1, TEST_2")
+        self.assertEqual(res["test-bp/test-ws-1"], "Bar, Foo")
         self.assertIn("test-bp/test-ws-2", res)
-        self.assertEqual(res["test-bp/test-ws-2"], "TEST_1, TEST_2")
+        self.assertEqual(res["test-bp/test-ws-2"], "Bar, Foo")
+        self.assertIn("test-bp/test-ws-3", res)
+        self.assertEqual(res["test-bp/test-ws-3"], "Bar")

--- a/primed/primed_anvil/tests/test_helpers.py
+++ b/primed/primed_anvil/tests/test_helpers.py
@@ -792,36 +792,71 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
 
     def test_non_consecutive_grouping(self):
         """Studies are grouped even if workspaces are listed non-consecutively."""
-        # This is attempting to capture an issue where:
+        # This replicates an issue seen in prod:
         # 1) there are multiple workspaces for the same set of studies
-        study_1 = StudyFactory.create(short_name="Foo")
-        study_2 = StudyFactory.create(short_name="Bar")
-        # study_3 = StudyFactory.create(short_name="Test")
-        study_accession_1 = dbGaPStudyAccessionFactory.create(studies=[study_1, study_2])
-        study_accession_2 = dbGaPStudyAccessionFactory.create(studies=[study_2])
-        workspace_1 = dbGaPWorkspaceFactory.create(
-            workspace__billing_project__name="test-bp",
-            workspace__name="test-ws-1",
+        # 2) objects are created in a specific order with specific alphabetizing.
+        # The difference in behavior between sqlite and mariadb is likely due to different ordering
+        # when the queryset results are returned, so debugging is tricky.
+        study_1 = StudyFactory.create(short_name="TEST_2")
+        study_2 = StudyFactory.create(short_name="TEST_1")
+        study_accession_1 = dbGaPStudyAccessionFactory.create(dbgap_phs=964, studies=[study_1, study_2])
+        study_accession_2 = dbGaPStudyAccessionFactory.create(dbgap_phs=286, studies=[study_2])
+        # Two workspaces associated with study_accession_1 (with two studies)
+        workspace_1_a = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-b",
+            workspace__name="test-a-b_c3",
             dbgap_study_accession=study_accession_1,
         )
-        WorkspaceGroupSharingFactory.create(workspace=workspace_1.workspace, group=self.primed_all_group)
-        workspace_2 = dbGaPWorkspaceFactory.create(
-            workspace__billing_project__name="test-bp",
-            workspace__name="test-ws-2",
+        WorkspaceGroupSharingFactory.create(workspace=workspace_1_a.workspace, group=self.primed_all_group)
+        workspace_2_a = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-a",
+            workspace__name="test-a_c3",
             dbgap_study_accession=study_accession_2,
         )
-        WorkspaceGroupSharingFactory.create(workspace=workspace_2.workspace, group=self.primed_all_group)
-        workspace_3 = dbGaPWorkspaceFactory.create(
-            workspace__billing_project__name="test-bp",
-            workspace__name="test-ws-3",
+        WorkspaceGroupSharingFactory.create(workspace=workspace_2_a.workspace, group=self.primed_all_group)
+        workspace_2_b = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-a",
+            workspace__name="test-a_c4",
+            dbgap_study_accession=study_accession_2,
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_2_b.workspace, group=self.primed_all_group)
+        workspace_2_c = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-a",
+            workspace__name="test-a_c2",
+            dbgap_study_accession=study_accession_2,
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_2_c.workspace, group=self.primed_all_group)
+        workspace_2_d = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-a",
+            workspace__name="test-a_c1",
+            dbgap_study_accession=study_accession_2,
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_2_d.workspace, group=self.primed_all_group)
+        workspace_1_b = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-b",
+            workspace__name="test-a-b_c4",
             dbgap_study_accession=study_accession_1,
         )
-        WorkspaceGroupSharingFactory.create(workspace=workspace_3.workspace, group=self.primed_all_group)
+        WorkspaceGroupSharingFactory.create(workspace=workspace_1_b.workspace, group=self.primed_all_group)
+        workspace_1_c = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-b",
+            workspace__name="test-a-b_c1",
+            dbgap_study_accession=study_accession_1,
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_1_c.workspace, group=self.primed_all_group)
+        workspace_1_d = dbGaPWorkspaceFactory.create(
+            workspace__billing_project__name="test-b",
+            workspace__name="test-a-b_c2",
+            dbgap_study_accession=study_accession_1,
+        )
+        WorkspaceGroupSharingFactory.create(workspace=workspace_1_d.workspace, group=self.primed_all_group)
         res = helpers.get_workspaces_for_phenotype_inventory()
-        self.assertEqual(len(res), 3)
-        self.assertIn("test-bp/test-ws-1", res)
-        self.assertEqual(res["test-bp/test-ws-1"], "Bar, Foo")
-        self.assertIn("test-bp/test-ws-2", res)
-        self.assertEqual(res["test-bp/test-ws-2"], "Bar")
-        self.assertIn("test-bp/test-ws-3", res)
-        self.assertEqual(res["test-bp/test-ws-3"], "Bar, Foo")
+        self.assertEqual(len(res), 8)
+        self.assertEqual(res["test-b/test-a-b_c1"], "TEST_1, TEST_2")
+        self.assertEqual(res["test-b/test-a-b_c2"], "TEST_1, TEST_2")
+        self.assertEqual(res["test-b/test-a-b_c3"], "TEST_1, TEST_2")
+        self.assertEqual(res["test-b/test-a-b_c4"], "TEST_1, TEST_2")
+        self.assertEqual(res["test-a/test-a_c1"], "TEST_1")
+        self.assertEqual(res["test-a/test-a_c2"], "TEST_1")
+        self.assertEqual(res["test-a/test-a_c3"], "TEST_1")
+        self.assertEqual(res["test-a/test-a_c4"], "TEST_1")

--- a/primed/primed_anvil/tests/test_helpers.py
+++ b/primed/primed_anvil/tests/test_helpers.py
@@ -808,13 +808,13 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         workspace_2 = dbGaPWorkspaceFactory.create(
             workspace__billing_project__name="test-bp",
             workspace__name="test-ws-2",
-            dbgap_study_accession=study_accession_1,
+            dbgap_study_accession=study_accession_2,
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_2.workspace, group=self.primed_all_group)
         workspace_3 = dbGaPWorkspaceFactory.create(
             workspace__billing_project__name="test-bp",
             workspace__name="test-ws-3",
-            dbgap_study_accession=study_accession_2,
+            dbgap_study_accession=study_accession_1,
         )
         WorkspaceGroupSharingFactory.create(workspace=workspace_3.workspace, group=self.primed_all_group)
         res = helpers.get_workspaces_for_phenotype_inventory()
@@ -822,6 +822,6 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         self.assertIn("test-bp/test-ws-1", res)
         self.assertEqual(res["test-bp/test-ws-1"], "Bar, Foo")
         self.assertIn("test-bp/test-ws-2", res)
-        self.assertEqual(res["test-bp/test-ws-2"], "Bar, Foo")
+        self.assertEqual(res["test-bp/test-ws-2"], "Bar")
         self.assertIn("test-bp/test-ws-3", res)
-        self.assertEqual(res["test-bp/test-ws-3"], "Bar")
+        self.assertEqual(res["test-bp/test-ws-3"], "Bar, Foo")

--- a/primed/primed_anvil/tests/test_helpers.py
+++ b/primed/primed_anvil/tests/test_helpers.py
@@ -862,7 +862,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         self.assertEqual(res["test-a/test-a_c4"], "TEST_1")
 
     def test_order_dbgap(self):
-        """dbGaPWorkspaces are ordered by billing project in results."""
+        """dbGaPWorkspaces are ordered by billing project and workspace in results."""
         workspace_1 = dbGaPWorkspaceFactory.create(
             workspace__billing_project__name="test-bp-2",
             workspace__name="test-ws-3",
@@ -885,7 +885,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         self.assertEqual(list(res)[2], "test-bp-2/test-ws-3")
 
     def test_order_cdsa(self):
-        """CDSAWorkspaces are ordered by billing project in results."""
+        """CDSAWorkspaces are ordered by billing project and workspace in results."""
         workspace_1 = CDSAWorkspaceFactory.create(
             workspace__billing_project__name="test-bp-2",
             workspace__name="test-ws-3",
@@ -908,7 +908,7 @@ class GetWorkspacesForPhenotypeInventoryTest(TestCase):
         self.assertEqual(list(res)[2], "test-bp-2/test-ws-3")
 
     def test_order_open_access(self):
-        """OpenAccessWorkspaces are ordered by billing project in results."""
+        """OpenAccessWorkspaces are ordered by billing project and workspace in results."""
         workspace_1 = OpenAccessWorkspaceFactory.create(
             workspace__billing_project__name="test-bp-2",
             workspace__name="test-ws-3",

--- a/primed/primed_anvil/tests/test_views.py
+++ b/primed/primed_anvil/tests/test_views.py
@@ -1247,8 +1247,8 @@ class DataSummaryTableTest(TestCase):
         self.assertEqual(len(response.context_data["summary_table"].rows), 1)
 
 
-class PhenotypeInventoryInputsViewTest(TestCase):
-    """Tests for the PhenotypeInventoryInputsView view."""
+class InventoryInputsViewTest(TestCase):
+    """Tests for the InventoryInputsView view."""
 
     def setUp(self):
         """Set up test class."""
@@ -1262,11 +1262,11 @@ class PhenotypeInventoryInputsViewTest(TestCase):
 
     def get_url(self, *args):
         """Get the url for the view being tested."""
-        return reverse("primed_anvil:utilities:phenotype_inventory_inputs", args=args)
+        return reverse("primed_anvil:utilities:inventory_inputs", args=args)
 
     def get_view(self):
         """Return the view being tested."""
-        return views.PhenotypeInventoryInputsView.as_view()
+        return views.InventoryInputsView.as_view()
 
     def test_view_redirect_not_logged_in(self):
         "View redirects to login view when user is not logged in."

--- a/primed/primed_anvil/urls.py
+++ b/primed/primed_anvil/urls.py
@@ -40,9 +40,9 @@ summary_patterns = (
 utilities_patterns = (
     [
         path(
-            "phenotype_inventory_inputs/",
-            views.PhenotypeInventoryInputsView.as_view(),
-            name="phenotype_inventory_inputs",
+            "inventory_inputs/",
+            views.InventoryInputsView.as_view(),
+            name="inventory_inputs",
         ),
     ],
     "utilities",

--- a/primed/primed_anvil/views.py
+++ b/primed/primed_anvil/views.py
@@ -180,10 +180,10 @@ class DataSummaryView(LoginRequiredMixin, TemplateView):
         return context
 
 
-class PhenotypeInventoryInputsView(AnVILConsortiumManagerStaffViewRequired, TemplateView):
-    template_name = "primed_anvil/phenotype_inventory_inputs.html"
+class InventoryInputsView(AnVILConsortiumManagerStaffViewRequired, TemplateView):
+    template_name = "primed_anvil/inventory_inputs.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["workspaces_input"] = json.dumps(helpers.get_workspaces_for_phenotype_inventory(), indent=2)
+        context["workspaces_input"] = json.dumps(helpers.get_workspaces_for_inventory(), indent=2)
         return context

--- a/primed/templates/anvil_consortium_manager/navbar.html
+++ b/primed/templates/anvil_consortium_manager/navbar.html
@@ -36,7 +36,7 @@
 
       <li><hr class="dropdown-divider"></li>
       <li>
-        <a class="dropdown-item" href="{% url 'primed_anvil:utilities:phenotype_inventory_inputs' %}">Phenotype inventory</a>
+        <a class="dropdown-item" href="{% url 'primed_anvil:utilities:inventory_inputs' %}">Inventory inputs</a>
       </li>
 
       <li><hr class="dropdown-divider"></li>

--- a/primed/templates/primed_anvil/inventory_inputs.html
+++ b/primed/templates/primed_anvil/inventory_inputs.html
@@ -11,7 +11,7 @@
 
 <p>
   This page creates the input for the "workspaces" field in the
-  <a href="https://dockstore.org/workflows/github.com/UW-GAC/primed-inventory-workflows/primed_phenotype_inventory:main?tab=info">PRIMED phenotype inventory workflow</a>.
+  <a href="https://dockstore.org/workflows/github.com/UW-GAC/primed-inventory-workflows/primed_inventory:main?tab=info">PRIMED phenotype inventory workflow</a>.
   Copy the text in the box below and paste it into the "workspaces" field when running the workflow on AnVIL.
 </p>
 


### PR DESCRIPTION
We've found a bug associated with the inventory inputs view/helper. In some cases, only one study is shown when a workspace is associated with multiple studies.

From inspecting prod data, it seems to occur when there are multiple workspaces associated with more than 1 study, and those workspaces are not listed in consecutive order when calling `itertools.groupby`.

Note that I was unable to get the new test to fail in CI, but from manual testing on the staging server, this appears to fix the issue.

Closes #675 