### PR TITLE
Clarify "has access" in study site member table

### DIFF
--- a/primed/cdsa/views.py
+++ b/primed/cdsa/views.py
@@ -356,9 +356,11 @@ class MemberAgreementDetail(viewmixins.SignedAgreementViewPermissionMixin, Singl
     model = models.MemberAgreement
 
     def get_table(self):
-        return UserAccountSingleGroupMembershipTable(
+        access_group_table = UserAccountSingleGroupMembershipTable(
             self.object.signed_agreement.accessors.all(), managed_group=self.object.signed_agreement.anvil_access_group
         )
+        access_group_table.columns["is_group_member"].column.verbose_name = "In access group?"
+        return access_group_table
 
     def get_object(self, queryset=None):
         """Look up the agreement by CDSA cc_id."""
@@ -438,14 +440,17 @@ class DataAffiliateAgreementDetail(viewmixins.SignedAgreementViewPermissionMixin
     model = models.DataAffiliateAgreement
 
     def get_tables(self):
+        access_group_table = UserAccountSingleGroupMembershipTable(
+            self.object.signed_agreement.accessors.all(), managed_group=self.object.signed_agreement.anvil_access_group
+        )
+        access_group_table.columns["is_group_member"].column.verbose_name = "In access group?"
+        upload_group_table = UserAccountSingleGroupMembershipTable(
+            self.object.uploaders.all(), managed_group=self.object.anvil_upload_group
+        )
+        upload_group_table.columns["is_group_member"].column.verbose_name = "In upload group?"
         return (
-            UserAccountSingleGroupMembershipTable(
-                self.object.signed_agreement.accessors.all(),
-                managed_group=self.object.signed_agreement.anvil_access_group,
-            ),
-            UserAccountSingleGroupMembershipTable(
-                self.object.uploaders.all(), managed_group=self.object.anvil_upload_group
-            ),
+            access_group_table,
+            upload_group_table,
         )
 
     def get_object(self, queryset=None):
@@ -519,9 +524,11 @@ class NonDataAffiliateAgreementDetail(viewmixins.SignedAgreementViewPermissionMi
     model = models.NonDataAffiliateAgreement
 
     def get_table(self):
-        return UserAccountSingleGroupMembershipTable(
+        access_group_table = UserAccountSingleGroupMembershipTable(
             self.object.signed_agreement.accessors.all(), managed_group=self.object.signed_agreement.anvil_access_group
         )
+        access_group_table.columns["is_group_member"].column.verbose_name = "In access group?"
+        return access_group_table
 
     def get_object(self, queryset=None):
         """Look up the agreement by CDSA cc_id."""

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -158,11 +158,13 @@ class dbGaPApplicationDetail(viewmixins.dbGaPApplicationViewPermissionMixin, Mul
             return None
 
     def get_tables(self):
+        access_group_table = UserAccountSingleGroupMembershipTable(
+            self.object.collaborators.all(), managed_group=self.object.anvil_access_group
+        )
+        access_group_table.columns["is_group_member"].column.verbose_name = "In access group?"
         return (
             tables.dbGaPDataAccessSnapshotTable(self.object.dbgapdataaccesssnapshot_set.all()),
-            UserAccountSingleGroupMembershipTable(
-                self.object.collaborators.all(), managed_group=self.object.anvil_access_group
-            ),
+            access_group_table,
         )
 
     def get_context_data(self, *args, **kwargs):

--- a/primed/primed_anvil/tables.py
+++ b/primed/primed_anvil/tables.py
@@ -177,7 +177,7 @@ class UserAccountSingleGroupMembershipTable(UserAccountTable):
     class Meta(UserAccountTable.Meta):
         pass
 
-    is_group_member = tables.BooleanColumn(verbose_name="Has access?", default=False)
+    is_group_member = tables.BooleanColumn(default=False)
 
     def __init__(self, *args, managed_group=None, **kwargs):
         if managed_group is None:

--- a/primed/primed_anvil/views.py
+++ b/primed/primed_anvil/views.py
@@ -128,6 +128,7 @@ class StudySiteDetail(AnVILConsortiumManagerStaffViewRequired, MultiTableMixin, 
         user_qs = User.objects.filter(is_active=True, study_sites=self.object)
         if self.object.member_group:
             user_table = tables.UserAccountSingleGroupMembershipTable(user_qs, managed_group=self.object.member_group)
+            user_table.columns["is_group_member"].column.verbose_name = "In members group?"
         else:
             user_table = tables.UserAccountTable(user_qs, exclude="study_sites")
         dbgap_qs = dbGaPApplication.objects.filter(principal_investigator__study_sites=self.object)

--- a/primed/templates/primed_anvil/studysite_detail.html
+++ b/primed/templates/primed_anvil/studysite_detail.html
@@ -59,7 +59,7 @@
       <h2 class="accordion-header" id="headingMembersOne">
         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMembersOne" aria-expanded="false" aria-controls="collapseMembersOne">
           <span class="fa-solid fa-cloud-arrow-down mx-2"></span>
-          View consortium members with data access
+          View AnVIL accounts in the Study Site member group
           <span class="badge mx-2 bg-secondary pill"> {{ tables.3.rows|length }}</span>
         </button>
       </h2>
@@ -81,7 +81,7 @@
       <h2 class="accordion-header" id="headingStudySiteUsersOne">
         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseStudySiteUsersOne" aria-expanded="false" aria-controls="collapseStudySiteUsersOne">
           <span class="fa-solid fa-user mx-2"></span>
-          Study Site members
+          View Study Site users
           <span class="badge mx-2 bg-secondary pill"> {{ tables.0.rows|length }}</span>
         </button>
       </h2>
@@ -89,6 +89,8 @@
         <div class="accordion-body">
           <p>
             This table shows users who are associated with this Study Site.
+            If the Study Site has an associated member group, the table also shows whether a user's AnVIL account is a member of that group.
+            Note that all study site members should be part of the members group if they have linked an account.
           </p>
         {% render_table tables.0 %}
         </div>


### PR DESCRIPTION
- Change the default verbose name of the `is_group_member` column from`UserAccountSingleGroupMembershipTable`
- Change the column name dynamically to an appropriate value in views (e.g., "in access group", "in upload group", etc.)
- Update wording on the StudySiteDetail template

Closes #673