### PR TITLE
Add a custom ManagedGroupAdapter

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -391,6 +391,7 @@ ANVIL_WORKSPACE_ADAPTERS = [
     "primed.miscellaneous_workspaces.adapters.DataPrepWorkspaceAdapter",
 ]
 ANVIL_ACCOUNT_ADAPTER = "primed.primed_anvil.adapters.AccountAdapter"
+ANVIL_MANAGED_GROUP_ADAPTER = "primed.primed_anvil.adapters.ManagedGroupAdapter"
 
 # Specify the URL name that AccountLink and AccountLinkVerify redirect to.
 ANVIL_ACCOUNT_LINK_REDIRECT = "users:redirect"

--- a/primed/primed_anvil/adapters.py
+++ b/primed/primed_anvil/adapters.py
@@ -1,9 +1,11 @@
 from anvil_consortium_manager.adapters.account import BaseAccountAdapter
+from anvil_consortium_manager.adapters.managed_group import BaseManagedGroupAdapter
 from anvil_consortium_manager.models import (
     GroupGroupMembership,
     ManagedGroup,
     WorkspaceGroupSharing,
 )
+from anvil_consortium_manager.tables import ManagedGroupStaffTable
 from django.conf import settings
 from django.db.models import Q
 
@@ -77,3 +79,23 @@ class WorkspaceAdminSharingAdapterMixin:
             can_compute=True,
         )
         sharing.anvil_create_or_update()
+
+
+class ManagedGroupAdapter(BaseManagedGroupAdapter):
+    """Adapter for ManagedGroups."""
+
+    list_table_class = ManagedGroupStaffTable
+
+    def after_anvil_create(self, managed_group):
+        super().after_anvil_create(managed_group)
+        # Add the ADMINs group as an admin of the auth domain.
+        try:
+            admins_group = ManagedGroup.objects.get(name=settings.ANVIL_CC_ADMINS_GROUP_NAME)
+        except ManagedGroup.DoesNotExist:
+            return
+        membership = GroupGroupMembership.objects.create(
+            parent_group=managed_group,
+            child_group=admins_group,
+            role=GroupGroupMembership.ADMIN,
+        )
+        membership.anvil_create()


### PR DESCRIPTION
This adapter automatically adds the CC ADMINS group to any group created by the app via the ManagedGroupCreate view.