### PR TITLE
Use Sequence for unique model fields in factories

### DIFF
--- a/primed/cdsa/tests/factories.py
+++ b/primed/cdsa/tests/factories.py
@@ -21,7 +21,7 @@ class AgreementMajorVersionFactory(DjangoModelFactory):
         model = models.AgreementMajorVersion
         django_get_or_create = ("version",)
 
-    version = Faker("random_int", min=1)
+    version = Sequence(lambda n: n + 1)
 
 
 class AgreementVersionFactory(DjangoModelFactory):

--- a/primed/primed_anvil/tests/factories.py
+++ b/primed/primed_anvil/tests/factories.py
@@ -30,5 +30,5 @@ class AvailableDataFactory(DjangoModelFactory):
     class Meta:
         model = models.AvailableData
 
-    name = Faker("catch_phrase")
+    name = Sequence(lambda n: "data:{0:07d}".format(n))
     description = Faker("paragraph")


### PR DESCRIPTION
This should eliminate errors due to accidentally creaitng or trying to create a new instance with the same value as another object that already exists.