### PR TITLE
Remove extra/unused classes in StudyList view

### DIFF
--- a/primed/primed_anvil/views.py
+++ b/primed/primed_anvil/views.py
@@ -77,7 +77,7 @@ class StudyDetail(AnVILConsortiumManagerViewRequired, MultiTableMixin, DetailVie
             )
 
 
-class StudyList(AnVILConsortiumManagerViewRequired, SingleTableView, FilterView, autocomplete.Select2QuerySetView):
+class StudyList(AnVILConsortiumManagerViewRequired, SingleTableMixin, FilterView):
     """View to show a list of `Study`s."""
 
     model = models.Study


### PR DESCRIPTION
They caused the view to only display 10 studies instead of the default 25, and were unnecessary - hey were either leftover from some other view or accidentally added.