### PR TITLE
Fix CI for upload artifact breaking change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
 
       - name: Merge coverage files
         run: |
+          ls -la ./artifacts/coverage-data*
           python -m coverage combine ./artifacts/coverage-data*/coverage-*
           python -m coverage xml
           ls -la .coverage*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run tests
         run:  |
-          pytest --cov=gregor_django -n auto
+          pytest --cov=primed -n auto
           mv .coverage coverage-${{ strategy.job-index }}
 
       - name: List files for debugging purposes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,8 @@ jobs:
 
       - name: Run tests
         run:  |
-          pytest --cov=primed -n auto
-          mv .coverage .coverage-${{ strategy.job-index }}
+          pytest --cov=gregor_django -n auto
+          mv .coverage coverage-${{ strategy.job-index }}
 
       - name: List files for debugging purposes
         run: ls -lhta
@@ -102,7 +102,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data-${{ strategy.job-index }}
-          path: .coverage-${{ strategy.job-index }}
+          path: coverage-${{ strategy.job-index }}
+          if-no-files-found: error
 
   coverage:
     needs:
@@ -129,7 +130,7 @@ jobs:
 
       - name: Merge coverage files
         run: |
-          python -m coverage combine ./artifacts/coverage-data*/.coverage-*
+          python -m coverage combine ./artifacts/coverage-data*/coverage-*
           python -m coverage xml
           ls -la .coverage*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
     steps:
 
       - name: Checkout Code Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -99,7 +99,7 @@ jobs:
         run: ls -lhta
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: coverage-data-${{ strategy.job-index }}
           path: coverage-${{ strategy.job-index }}
@@ -111,10 +111,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: '3.10'
 
@@ -124,7 +124,7 @@ jobs:
           pip install --upgrade coverage "django<4" django-coverage-plugin
 
       - name: Download coverage data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           path: ./artifacts/
 
@@ -139,6 +139,6 @@ jobs:
           python -m coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,10 +10,10 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v2.3.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout Code Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
         with:
           ref: ${{ github.head_ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
- pin all actions to their latest version, so updates can be handled by dependabot
- fix coverage steps so that it works with the latest version of github actions' upload-artifact (which includes a breaking change to not upload hidden files)