### PR TITLE
Fix absolute paths in requirements files with latest version of pip and pip-compile

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Temporarily pin pip-compile version
+        # The latest version of pip and pip-tools creates absolute paths instead of relative paths
+        # when compiling requirements files.
+        run: |
+          pip install --upgrade pip==24.3
+
       - name: Update requirements files
         uses: UW-GAC/pip-tools-actions/update-requirements-files@v0.1
         with:

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.10"
 
       - name: Update requirements files
-        uses: UW-GAC/pip-tools-actions/update-requirements-files@feature/remove-pip-upgrade
+        uses: UW-GAC/pip-tools-actions/update-requirements-files@v0.2
         with:
           requirements_files:  |-
             requirements/requirements.in

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -22,14 +22,8 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Temporarily pin pip-compile version
-        # The latest version of pip and pip-tools creates absolute paths instead of relative paths
-        # when compiling requirements files.
-        run: |
-          pip install --upgrade pip==24.3
-
       - name: Update requirements files
-        uses: UW-GAC/pip-tools-actions/update-requirements-files@v0.1
+        uses: UW-GAC/pip-tools-actions/update-requirements-files@feature/remove-pip-upgrade
         with:
           requirements_files:  |-
             requirements/requirements.in


### PR DESCRIPTION
Paths in the requirements.txt file get converted to absolute paths instead of relative paths. This can (temporarily?) be fixed by pinning pip to a specific version. Hopefully?