### PR TITLE
Maint/favicon notfound

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.shortcuts import redirect
 from django.urls import include, path
 from django.views import defaults as default_views
 from django.views.generic import TemplateView
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="pages/home.html"), name="home"),
@@ -27,7 +27,7 @@ urlpatterns = [
         "collaborative_analysis/",
         include("primed.collaborative_analysis.urls", namespace="collaborative_analysis"),
     ),
-    path("favicon.ico", lambda _: redirect("static/images/favicons/primed-favicon.png", permanent=True)),
+    path("favicon.ico", RedirectView.as_view(url="/static/images/favicons/primed-favicon.png", permanent=True)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.shortcuts import redirect
 from django.urls import include, path
 from django.views import defaults as default_views
 from django.views.generic import TemplateView
@@ -26,6 +27,7 @@ urlpatterns = [
         "collaborative_analysis/",
         include("primed.collaborative_analysis.urls", namespace="collaborative_analysis"),
     ),
+    path("favicon.ico", lambda _: redirect("static/images/favicons/primed-favicon.png", permanent=True)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 

--- a/primed/templates/admin/base_site.html
+++ b/primed/templates/admin/base_site.html
@@ -1,0 +1,7 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+{% block extrahead %}
+
+<link rel="shortcut icon" href="{% static 'images/favicons/primed-favicon.png' %}">
+
+{% endblock %}


### PR DESCRIPTION
Set favicon in admin base template.
Also redirect any requests we still get for favicon.ico to our custom favicon. Browsers will try to load this even when you have a different favicon set.