### PR TITLE
Check for Account active/inactive status when running dbGaP and CDSA audits

### DIFF
--- a/primed/cdsa/audit/accessor_audit.py
+++ b/primed/cdsa/audit/accessor_audit.py
@@ -272,24 +272,14 @@ class AccessorAudit(PRIMEDAudit):
                         )
                     )
             else:
-                if is_active:
-                    self.needs_action.append(
-                        RemoveAccess(
-                            signed_agreement=signed_agreement,
-                            user=user,
-                            member=account,
-                            note=self.NOT_ACCESSOR,
-                        )
+                self.needs_action.append(
+                    RemoveAccess(
+                        signed_agreement=signed_agreement,
+                        user=user,
+                        member=account,
+                        note=self.NOT_ACCESSOR,
                     )
-                else:
-                    self.needs_action.append(
-                        RemoveAccess(
-                            signed_agreement=signed_agreement,
-                            user=user,
-                            member=account,
-                            note=self.INACTIVE_ACCOUNT,
-                        )
-                    )
+                )
         else:
             if is_accessor:
                 if is_active:


### PR DESCRIPTION
Check that users' accounts are active or inactive when running CDSA and dbGaP audits. If a collaborator/accessor/uploader is inactive, they should not have access; if they are active, they should have access.

- Update auditing functionality int he cdsa and dbgap apps
- Add tests to check behavior

Closes #750