### PR TITLE
Switch account_verify_notification_email back to correct email

### DIFF
--- a/primed/primed_anvil/adapters.py
+++ b/primed/primed_anvil/adapters.py
@@ -23,7 +23,7 @@ class AccountAdapter(BaseAccountAdapter):
     If you do not have access to workspaces that you expect after 24 hours, please contact the CC."""
     account_link_verify_redirect = "users:redirect"
     account_link_email_subject = "Verify your AnVIL account email"
-    account_verify_notification_email = "foo@uw.edu"
+    account_verify_notification_email = "primedconsortium@uw.edu"
 
     def get_autocomplete_queryset(self, queryset, q):
         """Filter to Accounts where the email or the associated user name matches the query `q`."""


### PR DESCRIPTION
I had accidentally changed this to a test email when moving the settings and forgotten to change it back, so we were missing email notifications since b27ff1c3.