### PR TITLE
Indicate if a CDSA is deprecated in user profile

### DIFF
--- a/primed/templates/users/user_detail.html
+++ b/primed/templates/users/user_detail.html
@@ -129,7 +129,7 @@
               {% for app in dbgap_applications %}
               <li class="list-group-item">
                 <a href="{{ app.get_absolute_url }}">{{ app }}</a>
-                <div class="mx-3">
+                <div class="mx-3 mt-1">
                   <ul class="list-unstyled">
                     {% if object == app.principal_investigator %}
                     <li>Principal Investigator</li>
@@ -154,7 +154,7 @@
                 <span class="badge mx-2 {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
                   {{ agreement.get_status_display }}
                 </span>
-                <div class="mx-3">
+                <div class="mx-3 mt-1">
                   <ul class="list-unstyled">
                     {% if object == agreement.representative %}
                     <li>Representative</li>

--- a/primed/templates/users/user_detail.html
+++ b/primed/templates/users/user_detail.html
@@ -144,8 +144,8 @@
                 {% if object == agreement.representative %}
                   <li class="list-group-item">
                     Representative: <a href="{{ agreement.get_absolute_url }}">{{ agreement }}</a>
-                    <span class="badge {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
-                      {{ agreement.status }}
+                    <span class="badge mx-2 {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
+                      {{ agreement.get_status_display }}
                     </span>
                   </li>
                 {% endif %}

--- a/primed/templates/users/user_detail.html
+++ b/primed/templates/users/user_detail.html
@@ -144,16 +144,25 @@
                 {% if object == agreement.representative %}
                   <li class="list-group-item">
                     Representative: <a href="{{ agreement.get_absolute_url }}">{{ agreement }}</a>
+                    <span class="badge {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
+                      {{ agreement.status }}
+                    </span>
                   </li>
                 {% endif %}
                 {% if object in agreement.accessors.all %}
                   <li class="list-group-item">
                     Accessor: <a href="{{ agreement.get_absolute_url }}">{{ agreement }}</a>
+                    <span class="badge {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
+                      {{ agreement.status }}
+                    </span>
                   </li>
                 {% endif %}
                 {% if agreement.dataaffiliateagreement and object in agreement.dataaffiliateagreement.uploaders.all %}
                   <li class="list-group-item">
                     Uploader: <a href="{{ agreement.get_absolute_url }}">{{ agreement }}</a>
+                    <span class="badge {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
+                      {{ agreement.status }}
+                    </span>
                   </li>
                 {% endif %}
               {% endfor %}

--- a/primed/templates/users/user_detail.html
+++ b/primed/templates/users/user_detail.html
@@ -129,14 +129,15 @@
               {% for app in dbgap_applications %}
               <li class="list-group-item">
                 <a href="{{ app.get_absolute_url }}">{{ app }}</a>
-                <ul>
-                  {% if object == app.principal_investigator %}
-                  <li>Principal Investigator</li>
-                  {% else %}
-                  <li>Collaborator</li>
-                  {% endif %}
-
-                </ul>
+                <div class="mx-3">
+                  <ul class="list-unstyled">
+                    {% if object == app.principal_investigator %}
+                    <li>Principal Investigator</li>
+                    {% else %}
+                    <li>Collaborator</li>
+                    {% endif %}
+                  </ul>
+                </div>
               </li>
               {% endfor %}
             {% else %}
@@ -153,17 +154,19 @@
                 <span class="badge mx-2 {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
                   {{ agreement.get_status_display }}
                 </span>
-                <ul>
-                  {% if object == agreement.representative %}
-                  <li>Representative</li>
-                  {% endif %}
-                  {% if object in agreement.accessors.all %}
-                  <li>Accessor</li>
-                  {% endif %}
-                  {% if agreement.dataaffiliateagreement and object in agreement.dataaffiliateagreement.uploaders.all %}
-                  <li>Uploader</li>
-                  {% endif %}
-                </ul>
+                <div class="mx-3">
+                  <ul class="list-unstyled">
+                    {% if object == agreement.representative %}
+                    <li>Representative</li>
+                    {% endif %}
+                    {% if object in agreement.accessors.all %}
+                    <li>Accessor</li>
+                    {% endif %}
+                    {% if agreement.dataaffiliateagreement and object in agreement.dataaffiliateagreement.uploaders.all %}
+                    <li>Uploader</li>
+                    {% endif %}
+                  </ul>
+                </div>
               </li>
 
               {% endfor %}

--- a/primed/templates/users/user_detail.html
+++ b/primed/templates/users/user_detail.html
@@ -128,8 +128,15 @@
             {% if dbgap_applications %}
               {% for app in dbgap_applications %}
               <li class="list-group-item">
-                  {% if object == app.principal_investigator %}Principal Investigator{% else %}Collaborator{% endif %}:
                 <a href="{{ app.get_absolute_url }}">{{ app }}</a>
+                <ul>
+                  {% if object == app.principal_investigator %}
+                  <li>Principal Investigator</li>
+                  {% else %}
+                  <li>Collaborator</li>
+                  {% endif %}
+
+                </ul>
               </li>
               {% endfor %}
             {% else %}
@@ -141,35 +148,30 @@
             <li class="list-group-item"><h5 class>Consortium data sharing agreements</h5></li>
             {% if signed_agreements %}
               {% for agreement in signed_agreements %}
-                {% if object == agreement.representative %}
-                  <li class="list-group-item">
-                    Representative: <a href="{{ agreement.get_absolute_url }}">{{ agreement }}</a>
-                    <span class="badge mx-2 {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
-                      {{ agreement.get_status_display }}
-                    </span>
-                  </li>
-                {% endif %}
-                {% if object in agreement.accessors.all %}
-                  <li class="list-group-item">
-                    Accessor: <a href="{{ agreement.get_absolute_url }}">{{ agreement }}</a>
-                    <span class="badge {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
-                      {{ agreement.status }}
-                    </span>
-                  </li>
-                {% endif %}
-                {% if agreement.dataaffiliateagreement and object in agreement.dataaffiliateagreement.uploaders.all %}
-                  <li class="list-group-item">
-                    Uploader: <a href="{{ agreement.get_absolute_url }}">{{ agreement }}</a>
-                    <span class="badge {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
-                      {{ agreement.status }}
-                    </span>
-                  </li>
-                {% endif %}
+              <li class="list-group-item">
+                <a href="{{ agreement.get_absolute_url }}">{{ agreement }}</a>
+                <span class="badge mx-2 {% if agreement.status == agreement.StatusChoices.ACTIVE %}bg-success{% else %}bg-danger{% endif %}">
+                  {{ agreement.get_status_display }}
+                </span>
+                <ul>
+                  {% if object == agreement.representative %}
+                  <li>Representative</li>
+                  {% endif %}
+                  {% if object in agreement.accessors.all %}
+                  <li>Accessor</li>
+                  {% endif %}
+                  {% if agreement.dataaffiliateagreement and object in agreement.dataaffiliateagreement.uploaders.all %}
+                  <li>Uploader</li>
+                  {% endif %}
+                </ul>
+              </li>
+
               {% endfor %}
             {% else %}
               <li class="list-group-item">No CDSAs</li>
             {% endif %}
           </ul>
+
           <p class='alert alert-secondary'><i class="bi bi-question-circle-fill"></i> If this is incorrect, please contact the CC at <a href="mailto:{{ DCC_CONTACT_EMAIL }}">{{ DCC_CONTACT_EMAIL }}</a></p>
         </div>
       </div>

--- a/primed/users/tests/test_views.py
+++ b/primed/users/tests/test_views.py
@@ -556,7 +556,7 @@ class UserDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.user.get_absolute_url())
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '<span class="badge bg-success">active</span>', html=True)
+        self.assertContains(response, '<span class="badge mx-2 bg-success">Active</span>', html=True)
 
     def test_cdsa_accessor_withdrawn_agreement_shown_correct_badge(self):
         agreement = MemberAgreementFactory.create(signed_agreement__status=SignedAgreement.StatusChoices.WITHDRAWN)
@@ -564,7 +564,7 @@ class UserDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.user.get_absolute_url())
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '<span class="badge bg-danger">withdrawn</span>', html=True)
+        self.assertContains(response, '<span class="badge mx-2 bg-danger">Withdrawn</span>', html=True)
 
     def test_cdsa_accessor_replaced_agreement_shown_correct_badge(self):
         agreement = MemberAgreementFactory.create(signed_agreement__status=SignedAgreement.StatusChoices.REPLACED)
@@ -572,7 +572,7 @@ class UserDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.user.get_absolute_url())
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '<span class="badge bg-danger">replaced</span>', html=True)
+        self.assertContains(response, '<span class="badge mx-2 bg-danger">Replaced</span>', html=True)
 
     def test_cdsa_accessor_lapsed_agreement_shown_correct_badge(self):
         agreement = MemberAgreementFactory.create(signed_agreement__status=SignedAgreement.StatusChoices.LAPSED)
@@ -580,7 +580,7 @@ class UserDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.user.get_absolute_url())
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '<span class="badge bg-danger">lapsed</span>', html=True)
+        self.assertContains(response, '<span class="badge mx-2 bg-danger">Lapsed</span>', html=True)
 
     def test_acm_staff_view(self):
         """Users with staff view permission see dbGaP application info."""

--- a/primed/users/tests/test_views.py
+++ b/primed/users/tests/test_views.py
@@ -18,6 +18,7 @@ from django.shortcuts import resolve_url
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
+from primed.cdsa.models import SignedAgreement
 from primed.cdsa.tests.factories import (
     DataAffiliateAgreementFactory,
     MemberAgreementFactory,
@@ -548,6 +549,38 @@ class UserDetailTest(TestCase):
         self.assertIn("signed_agreements", response.context)
         self.assertEqual(len(response.context["signed_agreements"]), 1)
         self.assertIn(agreement.signed_agreement, response.context["signed_agreements"])
+
+    def test_cdsa_accessor_active_agreement_shown_correct_badge(self):
+        agreement = MemberAgreementFactory.create(signed_agreement__status=SignedAgreement.StatusChoices.ACTIVE)
+        agreement.signed_agreement.accessors.add(self.user)
+        self.client.force_login(self.user)
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<span class="badge bg-success">active</span>', html=True)
+
+    def test_cdsa_accessor_withdrawn_agreement_shown_correct_badge(self):
+        agreement = MemberAgreementFactory.create(signed_agreement__status=SignedAgreement.StatusChoices.WITHDRAWN)
+        agreement.signed_agreement.accessors.add(self.user)
+        self.client.force_login(self.user)
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<span class="badge bg-danger">withdrawn</span>', html=True)
+
+    def test_cdsa_accessor_replaced_agreement_shown_correct_badge(self):
+        agreement = MemberAgreementFactory.create(signed_agreement__status=SignedAgreement.StatusChoices.REPLACED)
+        agreement.signed_agreement.accessors.add(self.user)
+        self.client.force_login(self.user)
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<span class="badge bg-danger">replaced</span>', html=True)
+
+    def test_cdsa_accessor_lapsed_agreement_shown_correct_badge(self):
+        agreement = MemberAgreementFactory.create(signed_agreement__status=SignedAgreement.StatusChoices.LAPSED)
+        agreement.signed_agreement.accessors.add(self.user)
+        self.client.force_login(self.user)
+        response = self.client.get(self.user.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<span class="badge bg-danger">lapsed</span>', html=True)
 
     def test_acm_staff_view(self):
         """Users with staff view permission see dbGaP application info."""


### PR DESCRIPTION
- Show the status of each signed agreement object associated with the user.
- Indicate active status with a green badge and red badge for other statuses.
- Add tests that the template renders the correct status badge for each different status.
- Reorganize how data access mechanisms are shown in user detail page