### PR TITLE
More informative error/log messages when updating dbGaP DARs

### DIFF
--- a/primed/dbgap/models.py
+++ b/primed/dbgap/models.py
@@ -296,11 +296,11 @@ class dbGaPDataAccessSnapshot(TimeStampedModel, models.Model):
                     # Make sure that excepted values match.
                     # Is ValueError the best error to raise?
                     if previous_dar.dbgap_phs != phs:
-                        raise ValueError("dbgap_phs mismatch")
+                        raise ValueError(f"dbgap_phs mismatch. previous_dar: {previous_dar}.")
                     if previous_dar.dbgap_consent_code != request_json["consent_code"]:
-                        raise ValueError("dbgap_consent_code mismatch")
+                        raise ValueError(f"dbgap_consent_code mismatch. previous_dar: {previous_dar}.")
                     if previous_dar.dbgap_data_access_snapshot.dbgap_application.dbgap_project_id != project_id:
-                        raise ValueError("project_id mismatch")
+                        raise ValueError(f"project_id mismatch. previous_dar: {previous_dar}.")
                     # If everything looks good, pull the original version and participant set from the previous DAR.
                     original_version = previous_dar.original_version
                     original_participant_set = previous_dar.original_participant_set

--- a/primed/dbgap/tests/test_models.py
+++ b/primed/dbgap/tests/test_models.py
@@ -1017,7 +1017,7 @@ class dbGaPDataAccessSnapshotTest(TestCase):
         )
         with self.assertRaises(ValueError) as e:
             second_snapshot.create_dars_from_json()
-        self.assertIn("dbgap_phs", str(e.exception))
+        self.assertIn("dbgap_phs mismatch. previous_dar: 1234", str(e.exception))
         self.assertEqual(models.dbGaPDataAccessRequest.objects.count(), 1)
 
     @responses.activate
@@ -1059,7 +1059,7 @@ class dbGaPDataAccessSnapshotTest(TestCase):
         )
         with self.assertRaises(ValueError) as e:
             second_snapshot.create_dars_from_json()
-        self.assertIn("dbgap_consent_code", str(e.exception))
+        self.assertIn("dbgap_consent_code mismatch. previous_dar: 1234", str(e.exception))
         self.assertEqual(models.dbGaPDataAccessRequest.objects.count(), 1)
 
     @responses.activate
@@ -1099,7 +1099,7 @@ class dbGaPDataAccessSnapshotTest(TestCase):
         )
         with self.assertRaises(ValueError) as e:
             second_snapshot.create_dars_from_json()
-        self.assertIn("project_id", str(e.exception))
+        self.assertIn("project_id mismatch. previous_dar: 1234", str(e.exception))
         self.assertEqual(models.dbGaPDataAccessRequest.objects.count(), 1)
 
 


### PR DESCRIPTION
Add previous_dar to the error message in the ValueErrors in create_dars_from_json.
Update test_created_dars_from_json_assertion_error_phs test.