### PR TITLE
Feature/see dars associated with a given accession or workspace

### DIFF
--- a/primed/dbgap/adapters.py
+++ b/primed/dbgap/adapters.py
@@ -26,7 +26,6 @@ class dbGaPWorkspaceAdapter(WorkspaceAuthDomainAdapterMixin, WorkspaceAdminShari
         associated_data_prep = Workspace.objects.filter(dataprepworkspace__target_workspace=workspace)
         extra_context["associated_data_prep_workspaces"] = DataPrepWorkspaceUserTable(associated_data_prep)
         extra_context["data_prep_active"] = associated_data_prep.filter(dataprepworkspace__is_active=True).exists()
-        dbgap_workspace = self.workspace_data_model.objects.get(workspace=workspace)
-        data_access_requests = dbgap_workspace.get_data_access_requests(most_recent=True)
+        data_access_requests = workspace.dbgapworkspace.get_data_access_requests(most_recent=True)
         extra_context["associated_dars"] = tables.dbGaPDataAccessRequestTable(data_access_requests)
         return extra_context

--- a/primed/dbgap/adapters.py
+++ b/primed/dbgap/adapters.py
@@ -27,6 +27,6 @@ class dbGaPWorkspaceAdapter(WorkspaceAuthDomainAdapterMixin, WorkspaceAdminShari
         extra_context["associated_data_prep_workspaces"] = DataPrepWorkspaceUserTable(associated_data_prep)
         extra_context["data_prep_active"] = associated_data_prep.filter(dataprepworkspace__is_active=True).exists()
         dbgap_workspace = self.workspace_data_model.objects.get(workspace=workspace)
-        data_access_requests = dbgap_workspace.get_data_access_requests()
+        data_access_requests = dbgap_workspace.get_data_access_requests(most_recent=True)
         extra_context["associated_dars"] = tables.dbGaPDataAccessRequestTable(data_access_requests)
         return extra_context

--- a/primed/dbgap/adapters.py
+++ b/primed/dbgap/adapters.py
@@ -26,4 +26,7 @@ class dbGaPWorkspaceAdapter(WorkspaceAuthDomainAdapterMixin, WorkspaceAdminShari
         associated_data_prep = Workspace.objects.filter(dataprepworkspace__target_workspace=workspace)
         extra_context["associated_data_prep_workspaces"] = DataPrepWorkspaceUserTable(associated_data_prep)
         extra_context["data_prep_active"] = associated_data_prep.filter(dataprepworkspace__is_active=True).exists()
+        dbgap_workspace = self.workspace_data_model.objects.get(workspace=workspace)
+        data_access_requests = dbgap_workspace.get_data_access_requests()
+        extra_context["associated_dars"] = tables.dbGaPDataAccessRequestTable(data_access_requests)
         return extra_context

--- a/primed/dbgap/models.py
+++ b/primed/dbgap/models.py
@@ -55,6 +55,15 @@ class dbGaPStudyAccession(TimeStampedModel, models.Model):
     def get_absolute_url(self):
         return reverse("dbgap:dbgap_study_accessions:detail", kwargs={"dbgap_phs": self.dbgap_phs})
 
+    def get_data_access_requests(self, most_recent=False):
+        """Get a list of data access requests associated with this dbGaPStudyAccession."""
+        qs = dbGaPDataAccessRequest.objects.filter(
+            dbgap_phs=self.dbgap_phs,
+        )
+        if most_recent:
+            qs = qs.filter(dbgap_data_access_snapshot__is_most_recent=True)
+        return qs
+
 
 class dbGaPWorkspace(RequesterModel, DataUseOntologyModel, TimeStampedModel, BaseWorkspaceData):
     """A model to track additional data about dbGaP data in a workspace."""

--- a/primed/dbgap/tests/test_models.py
+++ b/primed/dbgap/tests/test_models.py
@@ -113,6 +113,75 @@ class dbGaPStudyAccessionTest(TestCase):
         self.assertIn(study_1, instance.studies.all())
         self.assertIn(study_2, instance.studies.all())
 
+    def test_get_data_access_requests_no_dars(self):
+        """Returns no results when there no DARs."""
+        instance = models.dbGaPStudyAccession(dbgap_phs=1)
+        self.assertEqual(len(instance.get_data_access_requests()), 0)
+
+    def test_get_data_access_requests_different_phs(self):
+        """Does not return a DAR where participant set doesn't match."""
+        instance = models.dbGaPStudyAccession(dbgap_phs=1)
+        factories.dbGaPDataAccessRequestFactory.create(dbgap_phs=instance.dbgap_phs + 1)
+        self.assertEqual(len(instance.get_data_access_requests()), 0)
+
+    def test_get_data_access_requests_one_snapshot_one_match(self):
+        """Returns 1 results when there is one matching DARs."""
+        instance = models.dbGaPStudyAccession(dbgap_phs=1)
+        dar = factories.dbGaPDataAccessRequestFactory.create(dbgap_phs=instance.dbgap_phs)
+        results = instance.get_data_access_requests()
+        self.assertEqual(len(results), 1)
+        self.assertIn(dar, results)
+
+    def test_get_data_access_requests_two_snapshots_most_recent_false(self):
+        """Returns 2 results when there are two matchign DARs from different snapshots of the same study accession."""
+        instance = models.dbGaPStudyAccession(dbgap_phs=1)
+        dbgap_application = factories.dbGaPApplicationFactory.create()
+        snapshot_1 = factories.dbGaPDataAccessSnapshotFactory.create(
+            dbgap_application=dbgap_application,
+            created=timezone.now() - timedelta(weeks=4),
+            is_most_recent=False,
+        )
+        snapshot_2 = factories.dbGaPDataAccessSnapshotFactory.create(
+            dbgap_application=dbgap_application,
+            created=timezone.now(),
+            is_most_recent=True,
+        )
+        dar_1 = factories.dbGaPDataAccessRequestFactory.create(
+            dbgap_phs=instance.dbgap_phs, dbgap_data_access_snapshot=snapshot_1
+        )
+        dar_2 = factories.dbGaPDataAccessRequestFactory(
+            dbgap_phs=instance.dbgap_phs, dbgap_data_access_snapshot=snapshot_2
+        )
+        results = instance.get_data_access_requests()
+        self.assertEqual(len(results), 2)
+        self.assertIn(dar_1, results)
+        self.assertIn(dar_2, results)
+
+    def test_get_data_access_requests_two_snapshots_most_recent_true(self):
+        """Returns 1 results when there are two matchign DARs from different snapshots of the same study accession."""
+        instance = models.dbGaPStudyAccession(dbgap_phs=1)
+        dbgap_application = factories.dbGaPApplicationFactory.create()
+        snapshot_1 = factories.dbGaPDataAccessSnapshotFactory.create(
+            dbgap_application=dbgap_application,
+            created=timezone.now() - timedelta(weeks=4),
+            is_most_recent=False,
+        )
+        snapshot_2 = factories.dbGaPDataAccessSnapshotFactory.create(
+            dbgap_application=dbgap_application,
+            created=timezone.now(),
+            is_most_recent=True,
+        )
+        dar_1 = factories.dbGaPDataAccessRequestFactory.create(
+            dbgap_phs=instance.dbgap_phs, dbgap_data_access_snapshot=snapshot_1
+        )
+        dar_2 = factories.dbGaPDataAccessRequestFactory(
+            dbgap_phs=instance.dbgap_phs, dbgap_data_access_snapshot=snapshot_2
+        )
+        results = instance.get_data_access_requests(most_recent=True)
+        self.assertEqual(len(results), 1)
+        self.assertNotIn(dar_1, results)
+        self.assertIn(dar_2, results)
+
 
 class dbGaPWorkspaceTest(TestCase):
     """Tests for the dbGaPWorkspace model."""

--- a/primed/dbgap/tests/test_models.py
+++ b/primed/dbgap/tests/test_models.py
@@ -182,6 +182,32 @@ class dbGaPStudyAccessionTest(TestCase):
         self.assertNotIn(dar_1, results)
         self.assertIn(dar_2, results)
 
+    def test_get_data_access_requests_two_applications(self):
+        """Returns 2 results when there are two DARs from two dbGaP applications."""
+        instance = models.dbGaPStudyAccession(dbgap_phs=1)
+        dbgap_application_1 = factories.dbGaPApplicationFactory.create()
+        snapshot_1 = factories.dbGaPDataAccessSnapshotFactory.create(
+            dbgap_application=dbgap_application_1,
+            created=timezone.now(),
+            is_most_recent=True,
+        )
+        dbgap_application_2 = factories.dbGaPApplicationFactory.create()
+        snapshot_2 = factories.dbGaPDataAccessSnapshotFactory.create(
+            dbgap_application=dbgap_application_2,
+            created=timezone.now(),
+            is_most_recent=True,
+        )
+        dar_1 = factories.dbGaPDataAccessRequestFactory.create(
+            dbgap_phs=instance.dbgap_phs, dbgap_data_access_snapshot=snapshot_1
+        )
+        dar_2 = factories.dbGaPDataAccessRequestFactory(
+            dbgap_phs=instance.dbgap_phs, dbgap_data_access_snapshot=snapshot_2
+        )
+        results = instance.get_data_access_requests(most_recent=True)
+        self.assertEqual(len(results), 2)
+        self.assertIn(dar_1, results)
+        self.assertIn(dar_2, results)
+
 
 class dbGaPWorkspaceTest(TestCase):
     """Tests for the dbGaPWorkspace model."""

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -973,6 +973,51 @@ class dbGaPWorkspaceDetailTest(TestCase):
         self.assertIn("data_prep_active", response.context_data)
         self.assertTrue(response.context["data_prep_active"])
 
+    def test_associated_DARs_table(self):
+        """The associated DARs table exists."""
+        obj = factories.dbGaPWorkspaceFactory.create()
+        self.client.force_login(self.user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("associated_dars", response.context_data)
+        self.assertIsInstance(response.context_data["associated_dars"], tables.dbGaPDataAccessRequestTable)
+
+    def test_associated_DARs_table_none(self):
+        """No associated DARs are shown if the dbGaPWorkspace does not have any DARs."""
+        obj = factories.dbGaPWorkspaceFactory.create()
+        self.client.force_login(self.user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("associated_dars", response.context_data)
+        self.assertEqual(len(response.context_data["associated_dars"].rows), 0)
+
+    def test_associated_DARs_one(self):
+        """One associated DARs is shown if the dbGaPWorkspace has one DARs."""
+        obj = factories.dbGaPWorkspaceFactory.create()
+        factories.dbGaPDataAccessRequestForWorkspaceFactory(dbgap_workspace=obj)
+        self.client.force_login(self.user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("associated_dars", response.context_data)
+        self.assertEqual(len(response.context_data["associated_dars"].rows), 1)
+
+    def test_associated_DARs_two(self):
+        """Two associated DARs are shown if the dbGaPWorkspace has two DARs."""
+        obj = factories.dbGaPWorkspaceFactory.create()
+        factories.dbGaPDataAccessRequestForWorkspaceFactory.create(dbgap_workspace=obj)
+        factories.dbGaPDataAccessRequestForWorkspaceFactory.create(dbgap_workspace=obj)
+        self.client.force_login(self.user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("associated_dars", response.context_data)
+        self.assertEqual(len(response.context_data["associated_dars"].rows), 2)
+
+    def test_shows_associated_DARs_for_only_this_dbGaPWorkspace(self):
+        """Only shows workspaces for this dbGaPWorkspace."""
+        obj = factories.dbGaPWorkspaceFactory.create()
+        other_workspace = factories.dbGaPWorkspaceFactory.create()
+        factories.dbGaPDataAccessRequestForWorkspaceFactory(dbgap_workspace=other_workspace)
+        self.client.force_login(self.user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("associated_dars", response.context_data)
+        self.assertEqual(len(response.context_data["associated_dars"].rows), 0)
+
 
 class dbGaPWorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
     """Tests of the WorkspaceCreate view from ACM with this app's dbGaPWorkspace model."""

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -331,6 +331,13 @@ class dbGaPStudyAccessionDetailTest(TestCase):
             ),
         )
 
+    def test_associated_DARs_table_staff_view_user(self):
+        """Staff view users do see the associated DARs table section."""
+        request = self.factory.get(self.get_url(self.obj.dbgap_phs))
+        request.user = self.user
+        response = self.get_view()(request, dbgap_phs=self.obj.dbgap_phs)
+        self.assertContains(response, "DARs associated with this accession")
+
     def test_associated_DARs_table(self):
         """The associated DARs table exists."""
         request = self.factory.get(self.get_url(self.obj.dbgap_phs))
@@ -972,6 +979,25 @@ class dbGaPWorkspaceDetailTest(TestCase):
         response = self.client.get(instance.get_absolute_url())
         self.assertIn("data_prep_active", response.context_data)
         self.assertTrue(response.context["data_prep_active"])
+
+    def test_associated_DARs_table_view_user(self):
+        """View users do not see the associated DARs table section"""
+        user = User.objects.create_user(username="test-view", password="test-view")
+        user.user_permissions.add(Permission.objects.get(codename=AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME))
+
+        obj = factories.dbGaPWorkspaceFactory.create()
+        DataPrepWorkspaceFactory.create(target_workspace=obj.workspace)
+        self.client.force_login(user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertNotContains(response, "DARs associated with this workspace")
+
+    def test_associated_DARs_table_staff_view_user(self):
+        """Staff view users do see the associated DARs table section."""
+        obj = factories.dbGaPWorkspaceFactory.create()
+        DataPrepWorkspaceFactory.create(target_workspace=obj.workspace)
+        self.client.force_login(self.user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertContains(response, "DARs associated with this workspace")
 
     def test_associated_DARs_table(self):
         """The associated DARs table exists."""

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -331,6 +331,51 @@ class dbGaPStudyAccessionDetailTest(TestCase):
             ),
         )
 
+    def test_associated_DARs_table(self):
+        """The associated DARs table exists."""
+        request = self.factory.get(self.get_url(self.obj.dbgap_phs))
+        request.user = self.user
+        response = self.get_view()(request, dbgap_phs=self.obj.dbgap_phs)
+        self.assertIn("associated_dars", response.context_data)
+        self.assertIsInstance(response.context_data["associated_dars"], tables.dbGaPDataAccessRequestTable)
+
+    def test_associated_DARs_table_none(self):
+        """No associated DARs are shown if the dbGaPStudyAccession does not have any DARs."""
+        request = self.factory.get(self.get_url(self.obj.dbgap_phs))
+        request.user = self.user
+        response = self.get_view()(request, dbgap_phs=self.obj.dbgap_phs)
+        self.assertIn("associated_dars", response.context_data)
+        self.assertEqual(len(response.context_data["associated_dars"].rows), 0)
+
+    def test_associated_DARs_one(self):
+        """One associated DARs is shown if the dbGaPStudyAccession has one DARs."""
+        factories.dbGaPDataAccessRequestFactory.create(dbgap_phs=self.obj.dbgap_phs)
+        request = self.factory.get(self.get_url(self.obj.dbgap_phs))
+        request.user = self.user
+        response = self.get_view()(request, dbgap_phs=self.obj.dbgap_phs)
+        self.assertIn("associated_dars", response.context_data)
+        self.assertEqual(len(response.context_data["associated_dars"].rows), 1)
+
+    def test_associated_DARs_two(self):
+        """Two associated DARs are shown if the dbGaPStudyAccession has two DARs."""
+        factories.dbGaPDataAccessRequestFactory.create(dbgap_dar_id=1, dbgap_phs=self.obj.dbgap_phs)
+        factories.dbGaPDataAccessRequestFactory.create(dbgap_dar_id=2, dbgap_phs=self.obj.dbgap_phs)
+        request = self.factory.get(self.get_url(self.obj.dbgap_phs))
+        request.user = self.user
+        response = self.get_view()(request, dbgap_phs=self.obj.dbgap_phs)
+        self.assertIn("associated_dars", response.context_data)
+        self.assertEqual(len(response.context_data["associated_dars"].rows), 2)
+
+    def test_shows_associated_DARs_for_only_this_dbGaPStudyAccession(self):
+        """Only shows workspaces for this dbGaPStudyAccession."""
+        other_dbgap_study_accession = factories.dbGaPStudyAccessionFactory.create()
+        factories.dbGaPDataAccessRequestFactory.create(dbgap_phs=other_dbgap_study_accession.dbgap_phs)
+        request = self.factory.get(self.get_url(self.obj.dbgap_phs))
+        request.user = self.user
+        response = self.get_view()(request, dbgap_phs=self.obj.dbgap_phs)
+        self.assertIn("associated_dars", response.context_data)
+        self.assertEqual(len(response.context_data["associated_dars"].rows), 0)
+
 
 class dbGaPStudyAccessionCreateTest(TestCase):
     """Tests for the dbGaPStudyAccessionCreate view."""

--- a/primed/dbgap/views.py
+++ b/primed/dbgap/views.py
@@ -74,6 +74,8 @@ class dbGaPStudyAccessionDetail(AnVILConsortiumManagerStaffViewRequired, SingleT
         context = super().get_context_data(**kwargs)
         edit_permission_codename = AnVILProjectManagerAccess.STAFF_EDIT_PERMISSION_CODENAME
         context["show_edit_links"] = self.request.user.has_perm("anvil_consortium_manager." + edit_permission_codename)
+        data_access_requests = self.object.get_data_access_requests(most_recent=True)
+        context["associated_dars"] = tables.dbGaPDataAccessRequestTable(data_access_requests)
         return context
 
 

--- a/primed/templates/dbgap/dbgapstudyaccession_detail.html
+++ b/primed/templates/dbgap/dbgapstudyaccession_detail.html
@@ -41,6 +41,8 @@
     </div>
   </div>
 
+  {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
+
   <div class="my-3">
     <div class="accordion" id="accordionAssociatedDAR">
       <div class="accordion-item">
@@ -62,6 +64,8 @@
       </div>
     </div>
   </div>
+
+  {% endif %}
 
 {% endblock after_panel %}
 

--- a/primed/templates/dbgap/dbgapstudyaccession_detail.html
+++ b/primed/templates/dbgap/dbgapstudyaccession_detail.html
@@ -20,6 +20,31 @@
 {% block after_panel %}
   <h3>Workspaces associated with this dbGaP study accession</h3>
   {% render_table workspace_table %}
+
+  <div class="my-3">
+    <div class="accordion" id="accordionAssociatedDAR">
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingAssociatedDAR">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+            data-bs-target="#collapseAssociatedDAR" aria-expanded="false" aria-controls="collapseAssociatedDAR">
+            <span class="fa-solid fa-circle-check mx-2"></span>
+            DARs associated with this accession
+            <span class="badge mx-2 {% if verified_table.rows|length %}bg-success{% else %}bg-secondary{% endif %} pill">
+              {{ associated_dars.rows|length }}</span>
+          </button>
+        </h2>
+        <div id="collapseAssociatedDAR" class="accordion-collapse collapse" aria-labelledby="headingAssociatedDAR"
+          data-bs-parent="#accordionAssociatedDAR">
+          <div class="accordion-body">
+
+            {% render_table associated_dars %}
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
 {% endblock after_panel %}
 
 {% block action_buttons %}

--- a/primed/templates/dbgap/dbgapstudyaccession_detail.html
+++ b/primed/templates/dbgap/dbgapstudyaccession_detail.html
@@ -19,26 +19,44 @@
 
 {% block after_panel %}
   <h3>Workspaces associated with this dbGaP study accession</h3>
-  {% render_table workspace_table %}
+
+  <div class="my-3">
+    <div class="accordion" id="accordionWorkspaces">
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingWorkspacesOne">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+            data-bs-target="#collapseWorkspacesOne" aria-expanded="false" aria-controls="collapseWorkspacesOne">
+            <span class="fa-solid fa-computer mx-2"></span>
+            Workspaces associated with this dbGaP study accession
+            <span class="badge mx-2 bg-secondary pill"> {{ workspace_table.rows|length }}</span>
+          </button>
+        </h2>
+        <div id="collapseWorkspacesOne" class="accordion-collapse collapse" aria-labelledby="headingWorkspacesOne"
+          data-bs-parent="#accordionWorkspaces">
+          <div class="accordion-body">
+            {% render_table workspace_table %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <div class="my-3">
     <div class="accordion" id="accordionAssociatedDAR">
       <div class="accordion-item">
-        <h2 class="accordion-header" id="headingAssociatedDAR">
+        <h2 class="accordion-header" id="headingAssociatedDAROne">
           <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
-            data-bs-target="#collapseAssociatedDAR" aria-expanded="false" aria-controls="collapseAssociatedDAR">
-            <span class="fa-solid fa-circle-check mx-2"></span>
+            data-bs-target="#collapseAssociatedDAROne" aria-expanded="false" aria-controls="collapseAssociatedDAROne">
+            <span class="fa-solid fa-list mx-2"></span>
             DARs associated with this accession
             <span class="badge mx-2 {% if verified_table.rows|length %}bg-success{% else %}bg-secondary{% endif %} pill">
               {{ associated_dars.rows|length }}</span>
           </button>
         </h2>
-        <div id="collapseAssociatedDAR" class="accordion-collapse collapse" aria-labelledby="headingAssociatedDAR"
+        <div id="collapseAssociatedDAROne" class="accordion-collapse collapse" aria-labelledby="headingAssociatedDAROne"
           data-bs-parent="#accordionAssociatedDAR">
           <div class="accordion-body">
-
             {% render_table associated_dars %}
-
           </div>
         </div>
       </div>

--- a/primed/templates/dbgap/dbgapworkspace_detail.html
+++ b/primed/templates/dbgap/dbgapworkspace_detail.html
@@ -92,6 +92,27 @@
   </div>
 </div>
 
+<div class="my-3">
+  <div class="accordion" id="accordionAssociatedDARs">
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="headingAssociatedDARs">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAssociatedDARs" aria-expanded="false" aria-controls="collapseAssociatedDARs">
+          <span class="fa-solid fa-circle-check mx-2"></span>
+          DARs associated with this workspace
+          <span class="badge mx-2 {% if verified_table.rows|length %}bg-success{% else %}bg-secondary{% endif %} pill"> {{ associated_dars.rows|length }}</span>
+        </button>
+      </h2>
+      <div id="collapseAssociatedDARs" class="accordion-collapse collapse" aria-labelledby="headingAssociatedDARs" data-bs-parent="#accordionAssociatedDARs">
+        <div class="accordion-body">
+
+          {% render_table associated_dars %}
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 {% include "snippets/data_prep_workspace_table.html" with table=associated_data_prep_workspaces is_active=data_prep_active %}
 
 {{block.super}}

--- a/primed/templates/dbgap/dbgapworkspace_detail.html
+++ b/primed/templates/dbgap/dbgapworkspace_detail.html
@@ -97,7 +97,7 @@
     <div class="accordion-item">
       <h2 class="accordion-header" id="headingAssociatedDARs">
         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAssociatedDARs" aria-expanded="false" aria-controls="collapseAssociatedDARs">
-          <span class="fa-solid fa-circle-check mx-2"></span>
+          <span class="fa-solid fa-list mx-2"></span>
           DARs associated with this workspace
           <span class="badge mx-2 {% if verified_table.rows|length %}bg-success{% else %}bg-secondary{% endif %} pill"> {{ associated_dars.rows|length }}</span>
         </button>

--- a/primed/templates/dbgap/dbgapworkspace_detail.html
+++ b/primed/templates/dbgap/dbgapworkspace_detail.html
@@ -92,6 +92,8 @@
   </div>
 </div>
 
+  {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
+
 <div class="my-3">
   <div class="accordion" id="accordionAssociatedDARs">
     <div class="accordion-item">
@@ -112,6 +114,8 @@
     </div>
   </div>
 </div>
+
+{% endif %}
 
 {% include "snippets/data_prep_workspace_table.html" with table=associated_data_prep_workspaces is_active=data_prep_active %}
 

--- a/primed/templates/dbgap/dbgapworkspace_detail.html
+++ b/primed/templates/dbgap/dbgapworkspace_detail.html
@@ -92,7 +92,11 @@
   </div>
 </div>
 
-  {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
+{{block.super}}
+
+{% include "snippets/data_prep_workspace_table.html" with table=associated_data_prep_workspaces is_active=data_prep_active %}
+
+{% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
 
 <div class="my-3">
   <div class="accordion" id="accordionAssociatedDARs">
@@ -117,9 +121,6 @@
 
 {% endif %}
 
-{% include "snippets/data_prep_workspace_table.html" with table=associated_data_prep_workspaces is_active=data_prep_active %}
-
-{{block.super}}
 {% endblock after_panel %}
 
 


### PR DESCRIPTION
- Add a new get_data_access_requests method to the dbGaPStudyAccession model
- On the dbGaPStudyAccessionDetail page, add a table of of DARs for that study accession using dbGaPStudyAccession.get_data_access_requests() with most_recent=True
- On the dbGaPWorkspace detail page, add a table of DARs associated with that workspace using dbGaPWorkspace.get_data_access_requests() method with most_recent=True
- Add tests for models and views for dbGaPStudyAccessionDetail and dbGaPWorkspaceDetail 
