### PR TITLE
dependabot ignore acm dependency 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     # Check for updates to GitHub Actions every weekday
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "django-anvil-consortium-manager"
     allow:
       # Allow only direct dependencies - should be ok with pip-sync?
       - dependency-type: "direct"


### PR DESCRIPTION
as it cannot handle git based python dependencies and is failing