### PR TITLE
Feature/automatically add a user to their studysites member group upon account link

### DIFF
--- a/docs/primed_anvil.rst
+++ b/docs/primed_anvil.rst
@@ -11,3 +11,17 @@ but only add users with approved access to the workspace's authorization domain 
 This allows users to see that the workspace exists, but only those with access can actually use it.
 
 Other workspace types (e.g., :class:`~primed.collaborative_analysis.models.CollaborativeAnalysisWorkspace`) use a different sharing and access strategy, which (if applicable) will be detailed in the specific app's documentation.
+
+
+Account linking and verification
+--------------------------------
+
+All PRIMED members are allowed to link their AnVIL accounts via the web app.
+After a user verifies their account, the account is automatically added to the following groups:
+
+    - The ``member_group`` associated with all :class:`~primed.primed_anvil.models.StudySite` objects that they are part of
+    - The ``anvil_access_group`` associated with all :class:`~primed.dbgap.models.dbGaPApplication` objects for which the user is a PI or collaborator
+    - The ``anvil_access_group`` associated with all :class:`~primed.cdsa.models.SignedAgreement` objects for which the user is a named accessor
+    - The ``anvil_upload_group`` associated with all :class:`~primed.cdsa.models.DataAffiliateAgreement` objects for which the user is a named uploader
+
+The notification email to the CC contains the list of groups that the account has automatically been added to.

--- a/primed/primed_anvil/adapters.py
+++ b/primed/primed_anvil/adapters.py
@@ -44,13 +44,14 @@ class AccountAdapter(BaseAccountAdapter):
     def after_account_verification(self, account):
         """Add the account to the member group for any StudySites that they are a part of."""
         super().after_account_verification(account)
-        # Get all StudySites that have a member_group
+        # Add the user to member groups for any StudySites that they are a part of.
         study_sites = StudySite.objects.select_related("member_group").filter(member_group__isnull=False)
         for site in study_sites:
             if site.member_group:
                 self._add_account_to_group(account, site.member_group)
 
         user = account.user
+        # Add the user to any dbGaP access groups that they are associated with.
         pi_apps = user.pi_dbgap_applications.select_related("anvil_access_group").all()
         collab_apps = user.collaborator_dbgap_applications.select_related("anvil_access_group").all()
         dbgap_applications = set(pi_apps) | set(collab_apps)
@@ -58,10 +59,17 @@ class AccountAdapter(BaseAccountAdapter):
             if app.anvil_access_group:
                 self._add_account_to_group(account, app.anvil_access_group)
 
-        signed_agreements = set(user.accessor_signed_agreements.select_related("anvil_access_group").all())
+        # Add the user to any CDSA SignedAgreement access groups that they are associated with.
+        signed_agreements = user.accessor_signed_agreements.select_related("anvil_access_group").all()
         for sa in signed_agreements:
             if sa.anvil_access_group:
                 self._add_account_to_group(account, sa.anvil_access_group)
+
+        # Add the user to DataAffiliateAgreement uploader groups that they are associated with.
+        data_affiliate_agreements = user.uploader_signed_agreements.select_related("anvil_upload_group").all()
+        for daa in data_affiliate_agreements:
+            if daa.anvil_upload_group:
+                self._add_account_to_group(account, daa.anvil_upload_group)
 
     def _add_account_to_group(self, account, group):
         if not GroupAccountMembership.objects.filter(group=group, account=account).exists():

--- a/primed/primed_anvil/adapters.py
+++ b/primed/primed_anvil/adapters.py
@@ -50,6 +50,12 @@ class AccountAdapter(BaseAccountAdapter):
             if site.member_group:
                 self._add_account_to_group(account, site.member_group)
 
+        user = account.user
+        dbgap_applications = set(user.pi_dbgap_applications.all()) | set(user.collaborator_dbgap_applications.all())
+        for app in dbgap_applications:
+            if app.anvil_access_group:
+                self._add_account_to_group(account, app.anvil_access_group)
+
     def _add_account_to_group(self, account, group):
         if not GroupAccountMembership.objects.filter(group=group, account=account).exists():
             membership = GroupAccountMembership(

--- a/primed/primed_anvil/adapters.py
+++ b/primed/primed_anvil/adapters.py
@@ -26,6 +26,7 @@ class AccountAdapter(BaseAccountAdapter):
     account_link_verify_redirect = "users:redirect"
     account_link_email_subject = "Verify your AnVIL account email"
     account_verification_notification_email = "primedconsortium@uw.edu"
+    account_verification_notification_template = "primed_anvil/account_notification_email.html"
 
     def get_autocomplete_queryset(self, queryset, q):
         """Filter to Accounts where the email or the associated user name matches the query `q`."""
@@ -80,6 +81,14 @@ class AccountAdapter(BaseAccountAdapter):
             )
             membership.save()
             membership.anvil_create()
+
+    def get_account_verification_notification_context(self, account):
+        """Get the context for the account verification notification email."""
+        context = super().get_account_verification_notification_context(account)
+        # Add the list of groups that the account is already in.
+        memberships = GroupAccountMembership.objects.filter(account=account)
+        context["memberships"] = memberships
+        return context
 
 
 class WorkspaceAuthDomainAdapterMixin:

--- a/primed/primed_anvil/adapters.py
+++ b/primed/primed_anvil/adapters.py
@@ -51,10 +51,17 @@ class AccountAdapter(BaseAccountAdapter):
                 self._add_account_to_group(account, site.member_group)
 
         user = account.user
-        dbgap_applications = set(user.pi_dbgap_applications.all()) | set(user.collaborator_dbgap_applications.all())
+        pi_apps = user.pi_dbgap_applications.select_related("anvil_access_group").all()
+        collab_apps = user.collaborator_dbgap_applications.select_related("anvil_access_group").all()
+        dbgap_applications = set(pi_apps) | set(collab_apps)
         for app in dbgap_applications:
             if app.anvil_access_group:
                 self._add_account_to_group(account, app.anvil_access_group)
+
+        signed_agreements = set(user.accessor_signed_agreements.select_related("anvil_access_group").all())
+        for sa in signed_agreements:
+            if sa.anvil_access_group:
+                self._add_account_to_group(account, sa.anvil_access_group)
 
     def _add_account_to_group(self, account, group):
         if not GroupAccountMembership.objects.filter(group=group, account=account).exists():

--- a/primed/primed_anvil/tests/test_adapters.py
+++ b/primed/primed_anvil/tests/test_adapters.py
@@ -10,6 +10,7 @@ from anvil_consortium_manager.tests.factories import (
 from anvil_consortium_manager.tests.utils import AnVILAPIMockTestMixin
 from django.test import TestCase, override_settings
 
+from primed.cdsa.tests.factories import SignedAgreementFactory
 from primed.dbgap.tests.factories import dbGaPApplicationFactory
 from primed.primed_anvil.tests.factories import StudySiteFactory
 from primed.users.tests.factories import UserFactory
@@ -167,7 +168,7 @@ class AccountAdapterTest(AnVILAPIMockTestMixin, TestCase):
         member_group = ManagedGroupFactory.create()
         user = UserFactory.create()
         app = dbGaPApplicationFactory.create(anvil_access_group=member_group)
-        app.collaborators.set([user])
+        app.collaborators.add(user)
         account = AccountFactory.create(user=user, verified=True)
         # API response for membership
         self.anvil_response_mock.add(
@@ -188,7 +189,7 @@ class AccountAdapterTest(AnVILAPIMockTestMixin, TestCase):
         member_group = ManagedGroupFactory.create()
         user = UserFactory.create()
         app = dbGaPApplicationFactory.create(principal_investigator=user, anvil_access_group=member_group)
-        app.collaborators.set([user])
+        app.collaborators.add(user)
         account = AccountFactory.create(user=user, verified=True)
         # API response for membership.
         self.anvil_response_mock.add(
@@ -209,7 +210,64 @@ class AccountAdapterTest(AnVILAPIMockTestMixin, TestCase):
         user = UserFactory.create()
         dbGaPApplicationFactory.create(principal_investigator=user, anvil_access_group=member_group_1)
         app_2 = dbGaPApplicationFactory.create(anvil_access_group=member_group_2)
-        app_2.collaborators.set([user])
+        app_2.collaborators.add(user)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group_1.name}/member/{account.email}",
+            status=204,
+        )
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group_2.name}/member/{account.email}",
+            status=204,
+        )
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 2)
+        membership = GroupAccountMembership.objects.get(group=member_group_1, account=account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+        membership = GroupAccountMembership.objects.get(group=member_group_2, account=account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+
+    def test_after_account_verification_no_signed_agreements(self):
+        """A user is not associated with any signed agreements."""
+        SignedAgreementFactory.create(anvil_access_group=ManagedGroupFactory.create())
+        account = AccountFactory.create(verified=True)
+        adapters.AccountAdapter().after_account_verification(account)
+        self.assertEqual(GroupAccountMembership.objects.count(), 0)
+
+    def test_after_account_verification_one_signed_agreement(self):
+        """A user is an accessor on one CDSA signed agreement."""
+        member_group = ManagedGroupFactory.create()
+        user = UserFactory.create()
+        sa = SignedAgreementFactory.create(anvil_access_group=member_group)
+        sa.accessors.add(user)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group.name}/member/{account.email}",
+            status=204,
+        )
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 1)
+        membership = GroupAccountMembership.objects.get()
+        self.assertEqual(membership.group, member_group)
+        self.assertEqual(membership.account, account)
+        self.assertEqual(membership.role, GroupGroupMembership.MEMBER)
+
+    def test_after_account_verification_multiple_signed_agreements(self):
+        """A user is an accessor on multiple signed agreements."""
+        member_group_1 = ManagedGroupFactory.create()
+        member_group_2 = ManagedGroupFactory.create()
+        user = UserFactory.create()
+        sa1 = SignedAgreementFactory.create(anvil_access_group=member_group_1)
+        sa1.accessors.add(user)
+        sa2 = SignedAgreementFactory.create(anvil_access_group=member_group_2)
+        sa2.accessors.add(user)
         account = AccountFactory.create(user=user, verified=True)
         # API response for membership.
         self.anvil_response_mock.add(

--- a/primed/templates/primed_anvil/account_notification_email.html
+++ b/primed/templates/primed_anvil/account_notification_email.html
@@ -1,0 +1,12 @@
+{% extends "anvil_consortium_manager/account_notification_email.html" %}
+
+{% block extra_content %}
+
+Group memberships:
+<ul>
+    {% for membership in memberships %}
+        <li>{{ membership }}</li>
+    {% endfor %}
+</ul>
+
+{% endblock extra_content %}


### PR DESCRIPTION
After after_account_verification, 
- Add the account to the member group for any StudySites that they are a part of.
- Add the account to any dbGaP access groups that they are associated with.
- Add the account to any CDSA SignedAgreement access groups that they are associated with. 
- Add the account to any CDSA DataAffiliateAgreement uploader groups that they are associated with.