### PR TITLE
Feature/add form validation for studysite in memberagreements

### DIFF
--- a/docs/cdsa.rst
+++ b/docs/cdsa.rst
@@ -55,6 +55,7 @@ Accessors are considered to be covered under the agreement can be added to the a
     - The user is listed as an accessor under the Signed Agreement. Note that the signing representative is not automatically considered as an accessor unless they are explicitly listed.
     - The user has a linked AnVIL account
     - The user's AnVIL account is active
+    - For MemberAgreements only: The study site associated with the MemberAgreement should match the study site of the signing representative. If this check fails, the agreement is flagged as an Error.
 
 
 The :class:`~primed.cdsa.audit.accessor_audit.AccessorAudit` auditing class is responsible for performing the above checks and storing the results.
@@ -67,7 +68,7 @@ The following results are possible:
     - :class:`~primed.cdsa.audit.accessor_audit.VerifiedNoAccess` - The user is not listed as an accessor under the agreement and is not a member of the agreement's ``anvil_access_group``.
     - :class:`~primed.cdsa.audit.accessor_audit.GrantAccess` - The user is listed as an accessor on the agreement, but is not a member of the agreement's ``anvil_access_group``. Action is needed to add the user to the access group.
     - :class:`~primed.cdsa.audit.accessor_audit.RemoveAccess` - The user is not listed as an accessor on the agreement, but is a member of the agreement's ``anvil_access_group``. Action is needed to remove the user from the access group.
-    - :class:`~primed.cdsa.audit.accessor_audit.Error` - An unexpected situation occurred and further exploration is necessary (e.g., a group is a member of the agreement's ``anvil_access_group``).
+    - :class:`~primed.cdsa.audit.accessor_audit.Error` - An unexpected situation occurred and further exploration is necessary (e.g., a group is a member of the agreement's ``anvil_access_group``, or the representative's study site does not match the MemberAgreement's study site).
 
 Viewing audit results
 `````````````````````

--- a/primed/cdsa/tests/factories.py
+++ b/primed/cdsa/tests/factories.py
@@ -66,12 +66,13 @@ class MemberAgreementFactory(DjangoModelFactory):
 
     @post_generation
     def add_study_site_to_representative(self, create, extracted, **kwargs):
-        # Add the study_site to the representative's study_sites.
+        # check and add study site to representative study sites
         if not create:
             # Simple build, do nothing.
             return
-        # Add the study site to the representative
-        self.signed_agreement.representative.study_sites.add(self.study_site)
+        # Add the study site to the representative if not already associated with this study site
+        if self.study_site not in self.signed_agreement.representative.study_sites.all():
+            self.signed_agreement.representative.study_sites.add(self.study_site)
 
     class Meta:
         model = models.MemberAgreement

--- a/primed/cdsa/tests/factories.py
+++ b/primed/cdsa/tests/factories.py
@@ -76,7 +76,7 @@ class MemberAgreementFactory(DjangoModelFactory):
 
     class Meta:
         model = models.MemberAgreement
-
+        skip_postgeneration_save = True
 
 class DataAffiliateAgreementFactory(DjangoModelFactory):
     signed_agreement = SubFactory(SignedAgreementFactory, type=models.SignedAgreement.DATA_AFFILIATE)

--- a/primed/cdsa/tests/factories.py
+++ b/primed/cdsa/tests/factories.py
@@ -64,6 +64,15 @@ class MemberAgreementFactory(DjangoModelFactory):
     study_site = SubFactory(StudySiteFactory)
     is_primary = True
 
+    @post_generation
+    def add_study_site_to_representative(self, create, extracted, **kwargs):
+        #Add the study_site to the representative's study_sites.
+        if not create:
+            # Simple build, do nothing.
+            return
+        # Add the study site to the representative
+        self.signed_agreement.representative.study_sites.add(self.study_site)
+
     class Meta:
         model = models.MemberAgreement
 

--- a/primed/cdsa/tests/factories.py
+++ b/primed/cdsa/tests/factories.py
@@ -66,7 +66,7 @@ class MemberAgreementFactory(DjangoModelFactory):
 
     @post_generation
     def add_study_site_to_representative(self, create, extracted, **kwargs):
-        #Add the study_site to the representative's study_sites.
+        # Add the study_site to the representative's study_sites.
         if not create:
             # Simple build, do nothing.
             return

--- a/primed/cdsa/tests/factories.py
+++ b/primed/cdsa/tests/factories.py
@@ -78,6 +78,7 @@ class MemberAgreementFactory(DjangoModelFactory):
         model = models.MemberAgreement
         skip_postgeneration_save = True
 
+
 class DataAffiliateAgreementFactory(DjangoModelFactory):
     signed_agreement = SubFactory(SignedAgreementFactory, type=models.SignedAgreement.DATA_AFFILIATE)
     study = SubFactory(StudyFactory)

--- a/primed/cdsa/tests/factories.py
+++ b/primed/cdsa/tests/factories.py
@@ -60,19 +60,16 @@ class SignedAgreementFactory(DjangoModelFactory):
 
 
 class MemberAgreementFactory(DjangoModelFactory):
-    signed_agreement = SubFactory(SignedAgreementFactory, type=models.SignedAgreement.MEMBER)
     study_site = SubFactory(StudySiteFactory)
+    signed_agreement = SubFactory(
+        SignedAgreementFactory,
+        type=models.SignedAgreement.MEMBER,
+        representative=SubFactory(
+            UserFactory,
+            study_sites=LazyAttribute(lambda user: [user.factory_parent.factory_parent.factory_parent.study_site]),
+        ),
+    )
     is_primary = True
-
-    @post_generation
-    def add_study_site_to_representative(self, create, extracted, **kwargs):
-        # check and add study site to representative study sites
-        if not create:
-            # Simple build, do nothing.
-            return
-        # Add the study site to the representative if not already associated with this study site
-        if self.study_site not in self.signed_agreement.representative.study_sites.all():
-            self.signed_agreement.representative.study_sites.add(self.study_site)
 
     class Meta:
         model = models.MemberAgreement
@@ -86,9 +83,9 @@ class DataAffiliateAgreementFactory(DjangoModelFactory):
     anvil_upload_group = SubFactory(
         ManagedGroupFactory,
         name=LazyAttribute(
-            lambda o: settings.ANVIL_DATA_ACCESS_GROUP_PREFIX
-            + "_CDSA_UPLOAD_"
-            + str(o.factory_parent.signed_agreement.cc_id)
+            lambda o: (
+                settings.ANVIL_DATA_ACCESS_GROUP_PREFIX + "_CDSA_UPLOAD_" + str(o.factory_parent.signed_agreement.cc_id)
+            )
         ),
     )
 

--- a/primed/cdsa/tests/test_audit.py
+++ b/primed/cdsa/tests/test_audit.py
@@ -342,13 +342,14 @@ class SignedAgreementAccessAuditTest(TestCase):
         """Member primary agreement with study site mismatch."""
         study_site_1 = StudySiteFactory.create()
         study_site_2 = StudySiteFactory.create()
-        representative = UserFactory.create()
+        representative = UserFactory.create(study_sites=[study_site_1])
         # Create agreement for study_site_2
         this_agreement = factories.MemberAgreementFactory.create(
             study_site=study_site_2,
             signed_agreement__representative=representative,
         )
         # Override the representative's study sites to associated with only study_site_1
+        # This is necessary because the factory adds the study site to the representative by default.
         this_agreement.signed_agreement.representative.study_sites.set([study_site_1])
 
         cdsa_audit = signed_agreement_audit.SignedAgreementAccessAudit()

--- a/primed/cdsa/tests/test_audit.py
+++ b/primed/cdsa/tests/test_audit.py
@@ -343,15 +343,11 @@ class SignedAgreementAccessAuditTest(TestCase):
         study_site_1 = StudySiteFactory.create()
         study_site_2 = StudySiteFactory.create()
         representative = UserFactory.create(study_sites=[study_site_1])
-        # Create agreement for study_site_2
+        # Create agreement for study_site_2, but the representative is only associated with study_site_1.
         this_agreement = factories.MemberAgreementFactory.create(
             study_site=study_site_2,
             signed_agreement__representative=representative,
         )
-        # Override the representative's study sites to associated with only study_site_1
-        # This is necessary because the factory adds the study site to the representative by default.
-        this_agreement.signed_agreement.representative.study_sites.set([study_site_1])
-
         cdsa_audit = signed_agreement_audit.SignedAgreementAccessAudit()
         cdsa_audit._audit_signed_agreement(this_agreement.signed_agreement)
         self.assertEqual(len(cdsa_audit.verified), 0)

--- a/primed/users/tests/factories.py
+++ b/primed/users/tests/factories.py
@@ -33,6 +33,16 @@ class UserFactory(DjangoModelFactory):
         django_get_or_create = ["username"]
         skip_postgeneration_save = True
 
+    @post_generation
+    def study_sites(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            # Simple build, or nothing to add, do nothing.
+            return
+
+        print(extracted)
+        # Add the iterable of groups using bulk addition
+        # self.study_sites.add(*extracted)
+
 
 class GroupFactory(DjangoModelFactory):
     name = Faker("name")

--- a/primed/users/tests/factories.py
+++ b/primed/users/tests/factories.py
@@ -39,9 +39,8 @@ class UserFactory(DjangoModelFactory):
             # Simple build, or nothing to add, do nothing.
             return
 
-        print(extracted)
         # Add the iterable of groups using bulk addition
-        # self.study_sites.add(*extracted)
+        self.study_sites.add(*extracted)
 
 
 class GroupFactory(DjangoModelFactory):


### PR DESCRIPTION
1. Add a clean method to the primed.cdsa.MemberAgreementForm
  - check that the representative can only sign agreements for study sites they're actually associated with
  - check that the representative is an active user
2. Add new checks in _audit_primary_agreement and _audit_component_agreement that agreement study site match representative study site. If it does not, the audit result will be OtherError with a new message.