### PR TITLE
Add a new DAR status when the status classes have staff_processing

### DIFF
--- a/dbgap_mhtml_parser.py
+++ b/dbgap_mhtml_parser.py
@@ -261,6 +261,8 @@ class dbGaPApplication:
             status = "new"
         elif status_classes == set(["staff_queued"]) and status_text == set(["dac review", "granted"]):
             status = "approved"
+        elif status_classes == set(["staff_processing"]) and status_text == set(["dac review", "granted"]):
+            status = "approved"
         else:
             raise (ValueError("Unknown DAR status"))
 


### PR DESCRIPTION
This case is similar to the staff_queued case, where the status text says "granted". Following the same logic, this should be "approved" as well.