### PR TITLE
Only add users' accounts to sites they are part of after account verification

### DIFF
--- a/primed/primed_anvil/adapters.py
+++ b/primed/primed_anvil/adapters.py
@@ -16,7 +16,6 @@ from django.conf import settings
 from django.db.models import Q
 
 from .filters import AccountListFilter
-from .models import StudySite
 from .tables import AccountTable
 
 
@@ -50,13 +49,15 @@ class AccountAdapter(BaseAccountAdapter):
     def after_account_verification(self, account):
         """Add the account to the member group for any StudySites that they are a part of."""
         super().after_account_verification(account)
+
+        user = account.user
+
         # Add the user to member groups for any StudySites that they are a part of.
-        study_sites = StudySite.objects.select_related("member_group").filter(member_group__isnull=False)
+        study_sites = user.study_sites.all()
         for site in study_sites:
             if site.member_group:
                 self._add_account_to_group(account, site.member_group)
 
-        user = account.user
         # Add the user to any dbGaP access groups that they are associated with.
         pi_apps = user.pi_dbgap_applications.select_related("anvil_access_group").all()
         collab_apps = user.collaborator_dbgap_applications.select_related("anvil_access_group").all()

--- a/primed/primed_anvil/tests/test_adapters.py
+++ b/primed/primed_anvil/tests/test_adapters.py
@@ -98,7 +98,28 @@ class AccountAdapterTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(membership.account, account)
         self.assertEqual(membership.role, GroupGroupMembership.RoleChoices.MEMBER)
 
-    def test_after_account_verification_two_study_sites(self):
+    def test_after_account_verification_two_study_sites_member_of_one(self):
+        """A user is part of two study sites."""
+        member_group_1 = ManagedGroupFactory.create()
+        study_site_1 = StudySiteFactory.create(member_group=member_group_1)
+        member_group_2 = ManagedGroupFactory.create()
+        StudySiteFactory.create(member_group=member_group_2)
+        user = UserFactory.create()
+        user.study_sites.add(study_site_1)
+        account = AccountFactory.create(user=user, verified=True)
+        # API response for study site membership.
+        self.anvil_response_mock.add(
+            responses.PUT,
+            self.api_client.sam_entry_point + f"/api/groups/v1/{member_group_1.name}/member/{account.email}",
+            status=204,
+        )
+        adapters.AccountAdapter().after_account_verification(account)
+        # Check for GroupGroupMembership.
+        self.assertEqual(GroupAccountMembership.objects.count(), 1)
+        membership = GroupAccountMembership.objects.get(group=member_group_1, account=account)
+        self.assertEqual(membership.role, GroupGroupMembership.RoleChoices.MEMBER)
+
+    def test_after_account_verification_two_study_sites_member_of_both(self):
         """A user is part of two study sites."""
         member_group_1 = ManagedGroupFactory.create()
         study_site_1 = StudySiteFactory.create(member_group=member_group_1)


### PR DESCRIPTION
The previous code was adding a user's account to the member group of *all* sites in the app, not just the sites that they are a part of. Fix this bug.