### PR TITLE
Fix intermittent test failure (hopefully)

### DIFF
--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -3328,7 +3328,7 @@ class dbGaPDataAccessSnapshotCreateMultipleTest(dbGaPResponseTestMixin, TestCase
         """Shows an error when one dbGaP application does not exist."""
         dbgap_application_1 = factories.dbGaPApplicationFactory.create()
         project_json_1 = factories.dbGaPJSONProjectFactory(dbgap_application=dbgap_application_1)
-        project_json_2 = factories.dbGaPJSONProjectFactory()
+        project_json_2 = factories.dbGaPJSONProjectFactory(Project_id=dbgap_application_1.dbgap_project_id + 999)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),


### PR DESCRIPTION
This test randomly failed with a requests/responses mocking failure, possibly because the second application was getting created with a dbGaP project id that already existed (possibly matching the project id of the first project?). This would have allowed the code to get to the step of making a request to get the current dbGaP version instead of failing with a form error.


Closes #1391 
hopefully