### PR TITLE
Remove django_get_or_create from CDSA factories

### DIFF
--- a/primed/cdsa/tests/factories.py
+++ b/primed/cdsa/tests/factories.py
@@ -19,7 +19,6 @@ class AgreementMajorVersionFactory(DjangoModelFactory):
 
     class Meta:
         model = models.AgreementMajorVersion
-        django_get_or_create = ("version",)
 
     version = Sequence(lambda n: n + 1)
 

--- a/primed/cdsa/tests/test_models.py
+++ b/primed/cdsa/tests/test_models.py
@@ -113,16 +113,17 @@ class AgreementVersionTest(TestCase):
 
     def test_full_version(self):
         """full_version property works as expected."""
+        major_version = factories.AgreementMajorVersionFactory.create(version=1)
         self.assertEqual(
-            factories.AgreementVersionFactory(major_version__version=1, minor_version=0).full_version,
+            factories.AgreementVersionFactory(major_version=major_version, minor_version=0).full_version,
             "v1.0",
         )
         self.assertEqual(
-            factories.AgreementVersionFactory(major_version__version=1, minor_version=5).full_version,
+            factories.AgreementVersionFactory(major_version=major_version, minor_version=5).full_version,
             "v1.5",
         )
         self.assertEqual(
-            factories.AgreementVersionFactory(major_version__version=1, minor_version=10).full_version,
+            factories.AgreementVersionFactory(major_version=major_version, minor_version=10).full_version,
             "v1.10",
         )
         self.assertEqual(

--- a/primed/cdsa/tests/test_views.py
+++ b/primed/cdsa/tests/test_views.py
@@ -254,13 +254,9 @@ class AgreementMajorVersionDetailTest(TestCase):
 
     def test_response_signed_agreement_table_three_agreements(self):
         """signed_agreement_table includes all types of agreements."""
-        factories.MemberAgreementFactory.create(signed_agreement__version__major_version__version=self.obj.version)
-        factories.DataAffiliateAgreementFactory.create(
-            signed_agreement__version__major_version__version=self.obj.version
-        )
-        factories.NonDataAffiliateAgreementFactory.create(
-            signed_agreement__version__major_version__version=self.obj.version
-        )
+        factories.MemberAgreementFactory.create(signed_agreement__version__major_version=self.obj)
+        factories.DataAffiliateAgreementFactory.create(signed_agreement__version__major_version=self.obj)
+        factories.NonDataAffiliateAgreementFactory.create(signed_agreement__version__major_version=self.obj)
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(self.obj.version))
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Update tests as needed to prevent errors, by creating the object and then using it instead of setting the same value multiple times when calling other factories.