### PR TITLE
Add members of the PRIMED_CC_WRITERS group directly to the Collaborative Analysis Workspace auth domains

### DIFF
--- a/primed/collaborative_analysis/audit.py
+++ b/primed/collaborative_analysis/audit.py
@@ -119,7 +119,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(PRIMEDAudit):
     INACTIVE_ACCOUNT = "Account is inactive."
 
     # Errors.
-    UNEXPECTED_GROUP_ACCESS = "Unexpected group added to the auth domain."
+    GROUP_NOT_ALLOWED = "Groups should not be in the auth domain."
 
     results_table_class = AccessAuditResultsTable
 
@@ -199,7 +199,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(PRIMEDAudit):
                 RemoveAccess(
                     collaborative_analysis_workspace=collaborative_analysis_workspace,
                     member=group,
-                    note=self.UNEXPECTED_GROUP_ACCESS,
+                    note=self.GROUP_NOT_ALLOWED,
                 )
             )
         else:
@@ -207,7 +207,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(PRIMEDAudit):
                 VerifiedNoAccess(
                     collaborative_analysis_workspace=collaborative_analysis_workspace,
                     member=group,
-                    note=self.NON_DCC_GROUP,
+                    note=self.GROUP_NOT_ALLOWED,
                 )
             )
 

--- a/primed/collaborative_analysis/audit.py
+++ b/primed/collaborative_analysis/audit.py
@@ -112,18 +112,14 @@ class CollaborativeAnalysisWorkspaceAccessAudit(PRIMEDAudit):
 
     # Allowed reasons for access.
     IN_SOURCE_AUTH_DOMAINS = "Account is in all source auth domains managed by the app for this workspace."
-    DCC_ACCESS = "CC groups are allowed access."
 
     # Allowed reasons for no access.
     NOT_IN_SOURCE_AUTH_DOMAINS = "Account is not in all source auth domains for this workspace."
-    NOT_IN_ANALYST_GROUP = "Account is not in the analyst group for this workspace."
+    NOT_IN_ANALYST_OR_CC_GROUP = "Account is not in the analyst or CC writer group for this workspace."
     INACTIVE_ACCOUNT = "Account is inactive."
-    NON_DCC_GROUP = "Non-CC groups are not allowed access."
 
     # Errors.
     UNEXPECTED_GROUP_ACCESS = "Unexpected group added to the auth domain."
-
-    ALLOWED_GROUP_NAMES = ("PRIMED_CC_WRITERS",)
 
     results_table_class = AccessAuditResultsTable
 
@@ -144,78 +140,61 @@ class CollaborativeAnalysisWorkspaceAccessAudit(PRIMEDAudit):
         # In the loop, run the _audit_workspace_and_account method.
         # Any remainig accounts in the auth domain that are not in the analyst group should be *errors*.
         analyst_group = workspace.analyst_group
-        analyst_memberships = GroupAccountMembership.objects.filter(group=analyst_group)
+        # CC group
+        try:
+            cc_group = ManagedGroup.objects.get(name=settings.ANVIL_CC_WRITERS_GROUP_NAME)
+        except ManagedGroup.DoesNotExist:
+            cc_group = None
+            accounts = Account.objects.filter(groupaccountmembership__group=analyst_group).distinct()
+            # GroupAccountMembership.objects.filter(group=analyst_group)
+        else:
+            accounts = Account.objects.filter(groupaccountmembership__group__in=[analyst_group, cc_group]).distinct()
+
         # Get a list of accounts in the auth domain.
-        auth_domain_membership = [
+        auth_domain_accounts = [
             x.account
             for x in GroupAccountMembership.objects.filter(group=workspace.workspace.authorization_domains.get())
         ]
-        for membership in analyst_memberships:
-            self._audit_workspace_and_account(workspace, membership.account)
+
+        for account in accounts:
+            self._audit_workspace_and_account(workspace, account)
             try:
-                auth_domain_membership.remove(membership.account)
+                auth_domain_accounts.remove(account)
             except ValueError:
                 # This is fine - this happens if the account is not in the auth domain.
                 pass
 
         # Loop over remaining accounts in the auth domain.
-        for account in auth_domain_membership:
+        for account in auth_domain_accounts:
             # Should this be an error, or a needs_action?
             # eg if an analyst is removed on purpose, it should be needs_action.
             self.errors.append(
                 RemoveAccess(
                     collaborative_analysis_workspace=workspace,
                     member=account,
-                    note=self.NOT_IN_ANALYST_GROUP,
+                    note=self.NOT_IN_ANALYST_OR_CC_GROUP,
                 )
             )
 
         # Check group access. Most groups should not have access.
-        group_memberships = (
-            GroupGroupMembership.objects.filter(
-                parent_group=workspace.workspace.authorization_domains.get(),
-            )
-            .exclude(
-                # Ignore cc admins group - it is handled differently because it should have admin privileges.
-                child_group__name=settings.ANVIL_CC_ADMINS_GROUP_NAME,
-            )
-            .exclude(
-                # Ignore allowed groups - they will be checked separately later.
-                child_group__name__in=self.ALLOWED_GROUP_NAMES,
-            )
+        group_memberships = GroupGroupMembership.objects.filter(
+            parent_group=workspace.workspace.authorization_domains.get(),
+        ).exclude(
+            # Ignore cc admins group - it is handled differently because it should have admin privileges.
+            child_group__name=settings.ANVIL_CC_ADMINS_GROUP_NAME,
         )
         for membership in group_memberships:
             self._audit_workspace_and_group(workspace, membership.child_group)
-        # Audit allowed groups
-        for group in ManagedGroup.objects.filter(name__in=self.ALLOWED_GROUP_NAMES):
-            self._audit_workspace_and_group(workspace, group)
+        # # Audit allowed groups
+        # for group in ManagedGroup.objects.filter(name__in=self.ALLOWED_GROUP_NAMES):
+        #     self._audit_workspace_and_group(workspace, group)
 
     def _audit_workspace_and_group(self, collaborative_analysis_workspace, group):
         """Audit access for a specific CollaborativeAnalysisWorkspace and group."""
-        # CC_WRITERS group should have access.
-        access_allowed = group.name in [
-            "PRIMED_CC_WRITERS",
-        ]
         in_auth_domain = collaborative_analysis_workspace.workspace.authorization_domains.get()
         auth_domain = collaborative_analysis_workspace.workspace.authorization_domains.get()
         in_auth_domain = GroupGroupMembership.objects.filter(parent_group=auth_domain, child_group=group).exists()
-        if access_allowed and in_auth_domain:
-            self.verified.append(
-                VerifiedAccess(
-                    collaborative_analysis_workspace=collaborative_analysis_workspace,
-                    member=group,
-                    note=self.DCC_ACCESS,
-                )
-            )
-        elif access_allowed and not in_auth_domain:
-            self.needs_action.append(
-                GrantAccess(
-                    collaborative_analysis_workspace=collaborative_analysis_workspace,
-                    member=group,
-                    note=self.DCC_ACCESS,
-                )
-            )
-        elif not access_allowed and in_auth_domain:
+        if in_auth_domain:
             self.errors.append(
                 RemoveAccess(
                     collaborative_analysis_workspace=collaborative_analysis_workspace,
@@ -244,11 +223,15 @@ class CollaborativeAnalysisWorkspaceAccessAudit(PRIMEDAudit):
         # - an account is in the workspace auth domain, but is not in the analyst group.
         # Get all groups for the account.
         account_groups = account.get_all_groups()
-        # Check whether the account is in the analyst group.
+        # Check whether the account is in the analyst group or any of the allowed CC groups.
         in_analyst_group = collaborative_analysis_workspace.analyst_group in account_groups
+        in_allowed_cc_group = GroupAccountMembership.objects.filter(
+            group__name__iexact=settings.ANVIL_CC_WRITERS_GROUP_NAME, account=account
+        ).exists()
+        in_allowed_group = in_analyst_group or in_allowed_cc_group
         # Check whether the account is in the auth domain of the collab workspace.
         in_auth_domain = collaborative_analysis_workspace.workspace.authorization_domains.get() in account_groups
-        if in_analyst_group:
+        if in_allowed_group:
             # Check whether access is allowed. Start by assuming yes, and then
             # set to false if the account should not have access.
             access_allowed = True
@@ -304,7 +287,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(PRIMEDAudit):
                     RemoveAccess(
                         collaborative_analysis_workspace=collaborative_analysis_workspace,
                         member=account,
-                        note=self.NOT_IN_ANALYST_GROUP,
+                        note=self.NOT_IN_ANALYST_OR_CC_GROUP,
                     )
                 )
             else:
@@ -312,7 +295,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(PRIMEDAudit):
                     VerifiedNoAccess(
                         collaborative_analysis_workspace=collaborative_analysis_workspace,
                         member=account,
-                        note=self.NOT_IN_ANALYST_GROUP,
+                        note=self.NOT_IN_ANALYST_OR_CC_GROUP,
                     )
                 )
 

--- a/primed/collaborative_analysis/tests/test_audit.py
+++ b/primed/collaborative_analysis/tests/test_audit.py
@@ -680,7 +680,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(record.member, account)
         self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
 
-    def test_in_collab_auth_domain_no_source_workspaces(self):
+    def test_analyst_in_collab_auth_domain_no_source_workspaces(self):
         # Create accounts.
         account = AccountFactory.create()
         # Set up workspace.
@@ -706,7 +706,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(record.member, account)
         self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
 
-    def test_not_in_collab_auth_domain_no_source_workspaces(self):
+    def test_analyst_not_in_collab_auth_domain_no_source_workspaces(self):
         # Create accounts.
         account = AccountFactory.create()
         # Set up workspace.
@@ -734,7 +734,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(record.member, account)
         self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
 
-    def test_in_collab_auth_domain_two_source_workspaces_in_both_auth_domains(self):
+    def test_analyst_in_collab_auth_domain_two_source_workspaces_in_both_auth_domains(self):
         # Create accounts.
         account = AccountFactory.create()
         # Set up workspace.
@@ -770,7 +770,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(record.member, account)
         self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
 
-    def test_in_collab_auth_domain_two_source_workspaces_in_one_auth_domains(self):
+    def test_analyst_in_collab_auth_domain_two_source_workspaces_in_one_auth_domains(self):
         # Create accounts.
         account = AccountFactory.create()
         # Set up workspace.
@@ -806,7 +806,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(record.member, account)
         self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
 
-    def test_in_collab_auth_domain_two_source_workspaces_in_neither_auth_domains(self):
+    def test_analyst_in_collab_auth_domain_two_source_workspaces_in_neither_auth_domains(self):
         # Create accounts.
         account = AccountFactory.create()
         # Set up workspace.
@@ -842,7 +842,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(record.member, account)
         self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
 
-    def test_not_in_collab_auth_domain_two_source_workspaces_in_both_auth_domains(self):
+    def test_analyst_not_in_collab_auth_domain_two_source_workspaces_in_both_auth_domains(self):
         # Create accounts.
         account = AccountFactory.create()
         # Set up workspace.
@@ -880,7 +880,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(record.member, account)
         self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
 
-    def test_not_in_collab_auth_domain_two_source_workspaces_in_one_auth_domains(self):
+    def test_analyst_not_in_collab_auth_domain_two_source_workspaces_in_one_auth_domains(self):
         # Create accounts.
         account = AccountFactory.create()
         # Set up workspace.
@@ -918,7 +918,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(record.member, account)
         self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
 
-    def test_not_in_collab_auth_domain_two_source_workspaces_in_neither_auth_domains(
+    def test_analyst_not_in_collab_auth_domain_two_source_workspaces_in_neither_auth_domains(
         self,
     ):
         # Create accounts.
@@ -983,7 +983,899 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(record.member, analyst_1)
         self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
 
-    def test_not_in_analyst_group(self):
+    def test_cc_writer_in_collab_auth_domain_in_source_auth_domain(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(
+            group=source_workspace.workspace.authorization_domains.get(),
+            account=account,
+        )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_not_in_source_auth_domain(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=source_workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.RemoveAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_source_auth_domain_not_managed_by_app(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = OpenAccessWorkspaceFactory.create()
+        # Add an auth domain not managed by the app.
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace, group__is_managed_by_app=False)
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_in_source_auth_domain(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(
+            group=source_workspace.workspace.authorization_domains.get(),
+            account=account,
+        )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.GrantAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_not_in_source_auth_domain(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=source_workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedNoAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_source_auth_domain_not_managed_by_app(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = OpenAccessWorkspaceFactory.create()
+        # Add an auth domain not managed by the app.
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace, group__is_managed_by_app=False)
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.GrantAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_two_source_auth_domains_in_both(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        source_auth_domain_2 = WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(
+            group=source_workspace.workspace.authorization_domains.all()[0],
+            account=account,
+        )
+        GroupAccountMembershipFactory.create(
+            group=source_auth_domain_2.group,
+            account=account,
+        )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_two_source_auth_domains_in_one(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace)
+        # add an extra auth doamin
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(
+            group=source_workspace.workspace.authorization_domains.first(),
+            account=account,
+        )
+        # GroupAccountMembershipFactory.create(
+        #     group=source_auth_domain_2.group,
+        #     account=account,
+        # )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.RemoveAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_two_source_auth_domains_in_neither(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace)
+        # add an extra auth doamin
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=source_workspace.workspace.authorization_domains.get(),
+        #     account=account,
+        # )
+        # GroupAccountMembershipFactory.create(
+        #     group=source_auth_domain_2.group,
+        #     account=account,
+        # )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.RemoveAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_two_source_auth_domains_in_one_and_one_not_managed_by_app(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        source_auth_domain = source_workspace.workspace.authorization_domains.get()
+        # Add an auth domain not managed by the app.
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace, group__is_managed_by_app=False)
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        GroupAccountMembershipFactory.create(group=source_auth_domain, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(group=source_auth_domain, account=account)
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_two_source_auth_domains_not_in_one_and_one_not_managed_by_app(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        source_workspace.workspace.authorization_domains.get()
+        # Add an auth domain not managed by the app.
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace, group__is_managed_by_app=False)
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # GroupAccountMembershipFactory.create(group=source_auth_domain, account=account)
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.RemoveAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_two_source_auth_domains_in_both(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        source_auth_domain_1 = source_workspace.workspace.authorization_domains.get()
+        source_auth_domain_2 = WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(
+            group=source_auth_domain_1,
+            account=account,
+        )
+        GroupAccountMembershipFactory.create(
+            group=source_auth_domain_2.group,
+            account=account,
+        )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.GrantAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_two_source_auth_domains_in_one(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        source_auth_domain_2 = WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=source_auth_domain_1,
+        #     account=account,
+        # )
+        GroupAccountMembershipFactory.create(
+            group=source_auth_domain_2.group,
+            account=account,
+        )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedNoAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_two_source_auth_domains_in_neither(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace.workspace)
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=source_auth_domain_1,
+        #     account=account,
+        # )
+        # GroupAccountMembershipFactory.create(
+        #     group=source_auth_domain_2.group,
+        #     account=account,
+        # )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedNoAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_two_source_auth_domains_in_one_and_one_not_managed_by_app(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        source_auth_domain = source_workspace.workspace.authorization_domains.get()
+        # Add an auth domain not managed by the app.
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace, group__is_managed_by_app=False)
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        GroupAccountMembershipFactory.create(group=source_auth_domain, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(group=source_auth_domain, account=account)
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.GrantAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_two_source_auth_domains_not_in_one_and_one_not_managed_by_app(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = dbGaPWorkspaceFactory.create()
+        # source_auth_domain = source_workspace.workspace.authorization_domains.get()
+        # Add an auth domain not managed by the app.
+        WorkspaceAuthorizationDomainFactory.create(workspace=source_workspace.workspace, group__is_managed_by_app=False)
+        workspace.source_workspaces.add(source_workspace.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # GroupAccountMembershipFactory.create(group=source_auth_domain, account=account)
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedNoAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_no_source_workspaces(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = WorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_no_source_workspaces(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace = WorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.GrantAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_two_source_workspaces_in_both_auth_domains(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace_1 = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_1.workspace)
+        source_workspace_2 = CDSAWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_2.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(
+            group=source_workspace_1.workspace.authorization_domains.get(),
+            account=account,
+        )
+        GroupAccountMembershipFactory.create(
+            group=source_workspace_2.workspace.authorization_domains.get(),
+            account=account,
+        )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_two_source_workspaces_in_one_auth_domains(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace_1 = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_1.workspace)
+        source_workspace_2 = CDSAWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_2.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(
+            group=source_workspace_1.workspace.authorization_domains.get(),
+            account=account,
+        )
+        # GroupAccountMembershipFactory.create(
+        #     group=source_workspace_2.workspace.authorization_domains.get(),
+        #     account=account,
+        # )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.RemoveAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_in_collab_auth_domain_two_source_workspaces_in_neither_auth_domains(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace_1 = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_1.workspace)
+        source_workspace_2 = CDSAWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_2.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=source_workspace_1.workspace.authorization_domains.get(),
+        #     account=account,
+        # )
+        # GroupAccountMembershipFactory.create(
+        #     group=source_workspace_2.workspace.authorization_domains.get(),
+        #     account=account,
+        # )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.RemoveAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_two_source_workspaces_in_both_auth_domains(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace_1 = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_1.workspace)
+        source_workspace_2 = CDSAWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_2.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(
+            group=source_workspace_1.workspace.authorization_domains.get(),
+            account=account,
+        )
+        GroupAccountMembershipFactory.create(
+            group=source_workspace_2.workspace.authorization_domains.get(),
+            account=account,
+        )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.GrantAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_two_source_workspaces_in_one_auth_domains(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace_1 = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_1.workspace)
+        source_workspace_2 = CDSAWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_2.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        GroupAccountMembershipFactory.create(
+            group=source_workspace_1.workspace.authorization_domains.get(),
+            account=account,
+        )
+        # GroupAccountMembershipFactory.create(
+        #     group=source_workspace_2.workspace.authorization_domains.get(),
+        #     account=account,
+        # )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedNoAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_cc_writer_not_in_collab_auth_domain_two_source_workspaces_in_neither_auth_domains(
+        self,
+    ):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Set up source workspaces.
+        source_workspace_1 = dbGaPWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_1.workspace)
+        source_workspace_2 = CDSAWorkspaceFactory.create()
+        workspace.source_workspaces.add(source_workspace_2.workspace)
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # Source workspace auth domains membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=source_workspace_1.workspace.authorization_domains.get(),
+        #     account=account,
+        # )
+        # GroupAccountMembershipFactory.create(
+        #     group=source_workspace_2.workspace.authorization_domains.get(),
+        #     account=account,
+        # )
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        # GroupAccountMembershipFactory.create(
+        #     group=workspace.workspace.authorization_domains.get(), account=account
+        # )
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedNoAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.NOT_IN_SOURCE_AUTH_DOMAINS)
+
+    def test_two_cc_writers(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Create an cc_writer that needs access.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        cc_writer_1 = AccountFactory.create()
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=cc_writer_1)
+        # Create an cc_writer that has access.
+        cc_writer_2 = AccountFactory.create()
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=cc_writer_2)
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=cc_writer_2)
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        collab_audit._audit_workspace(workspace)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, cc_writer_2)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+        record = collab_audit.needs_action[0]
+        self.assertIsInstance(record, audit.GrantAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, cc_writer_1)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_in_both_analyst_group_and_cc_writer_group(self):
+        account = AccountFactory.create()
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
+        # Member of both CC writers and analyst group
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        GroupAccountMembershipFactory.create(group=workspace.analyst_group, account=account)
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        collab_audit._audit_workspace(workspace)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
+    def test_not_in_analyst_group_or_cc_writer_group_in_collab_auth_domain(self):
         # Create an analyst that needs access.
         workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
         # Create an analyst that has access but is not in the analyst group.
@@ -998,7 +1890,19 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertIsInstance(record, audit.RemoveAccess)
         self.assertEqual(record.collaborative_analysis_workspace, workspace)
         self.assertEqual(record.member, analyst)
-        self.assertEqual(record.note, collab_audit.NOT_IN_ANALYST_GROUP)
+        self.assertEqual(record.note, collab_audit.NOT_IN_ANALYST_OR_CC_GROUP)
+
+    def test_not_in_analyst_group_or_cc_writer_group_not_in_collab_auth_domain(self):
+        # Create an analyst that needs access.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Create an analyst that has access but is not in the analyst group.
+        AccountFactory.create()
+        # GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=analyst)
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        collab_audit._audit_workspace(workspace)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
 
     def test_unexpected_group_in_auth_domain(self):
         workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
@@ -1048,10 +1952,54 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(len(collab_audit.needs_action), 0)
         self.assertEqual(len(collab_audit.errors), 0)
 
+    @override_settings(ANVIL_CC_WRITERS_GROUP_NAME="FOOBAR")
+    def test_different_cc_writers_group_name(self):
+        # CC writer group
+        cc_writer_group = ManagedGroupFactory.create(name="FOOBAR")
+        # Create accounts.
+        account = AccountFactory.create()
+        # Set up workspace.
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # cc_writer group membership.
+        GroupAccountMembershipFactory.create(group=cc_writer_group, account=account)
+        # CollaborativeAnalysisWorkspace auth domain membership.
+        GroupAccountMembershipFactory.create(group=workspace.workspace.authorization_domains.get(), account=account)
+        # Set up audit
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        # Run audit
+        collab_audit._audit_workspace_and_account(workspace, account)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, account)
+        self.assertEqual(record.note, collab_audit.IN_SOURCE_AUTH_DOMAINS)
+
     def test_error_for_primed_cc_members_group(self):
         workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
         # Add a group to the auth domain.
         group = ManagedGroupFactory.create(name="PRIMED_CC_MEMBERS")
+        GroupGroupMembershipFactory.create(
+            parent_group=workspace.workspace.authorization_domains.get(),
+            child_group=group,
+        )
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        collab_audit._audit_workspace(workspace)
+        self.assertEqual(len(collab_audit.verified), 0)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 1)
+        record = collab_audit.errors[0]
+        self.assertIsInstance(record, audit.RemoveAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, group)
+        self.assertEqual(record.note, collab_audit.UNEXPECTED_GROUP_ACCESS)
+
+    def test_error_for_primed_cc_writers_group(self):
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Add a group to the auth domain.
+        group = ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
         GroupGroupMembershipFactory.create(
             parent_group=workspace.workspace.authorization_domains.get(),
             child_group=group,
@@ -1081,29 +2029,10 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertEqual(len(collab_audit.needs_action), 0)
         self.assertEqual(len(collab_audit.errors), 0)
 
-    def test_verified_access_for_primed_cc_writers_group(self):
+    def test_no_access_for_primed_cc_writers_group(self):
         workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
         # Add a group to the auth domain.
-        group = ManagedGroupFactory.create(name="PRIMED_CC_WRITERS")
-        GroupGroupMembershipFactory.create(
-            parent_group=workspace.workspace.authorization_domains.get(),
-            child_group=group,
-        )
-        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
-        collab_audit._audit_workspace(workspace)
-        self.assertEqual(len(collab_audit.verified), 1)
-        self.assertEqual(len(collab_audit.needs_action), 0)
-        self.assertEqual(len(collab_audit.errors), 0)
-        record = collab_audit.verified[0]
-        self.assertIsInstance(record, audit.VerifiedAccess)
-        self.assertEqual(record.collaborative_analysis_workspace, workspace)
-        self.assertEqual(record.member, group)
-        self.assertEqual(record.note, collab_audit.DCC_ACCESS)
-
-    def test_grant_access_for_primed_cc_writers_group(self):
-        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
-        # Add a group to the auth domain.
-        group = ManagedGroupFactory.create(name="PRIMED_CC_WRITERS")
+        ManagedGroupFactory.create(name="TEST_PRIMED_CC_WRITERS")
         # GroupGroupMembershipFactory.create(
         #     parent_group=workspace.workspace.authorization_domains.get(),
         #     child_group=group,
@@ -1111,13 +2040,8 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
         collab_audit._audit_workspace(workspace)
         self.assertEqual(len(collab_audit.verified), 0)
-        self.assertEqual(len(collab_audit.needs_action), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
         self.assertEqual(len(collab_audit.errors), 0)
-        record = collab_audit.needs_action[0]
-        self.assertIsInstance(record, audit.GrantAccess)
-        self.assertEqual(record.collaborative_analysis_workspace, workspace)
-        self.assertEqual(record.member, group)
-        self.assertEqual(record.note, collab_audit.DCC_ACCESS)
 
     def test_two_workspaces(self):
         # Create a workspace with an analyst that needs access.

--- a/primed/collaborative_analysis/tests/test_audit.py
+++ b/primed/collaborative_analysis/tests/test_audit.py
@@ -1921,7 +1921,22 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertIsInstance(record, audit.RemoveAccess)
         self.assertEqual(record.collaborative_analysis_workspace, workspace)
         self.assertEqual(record.member, group)
-        self.assertEqual(record.note, collab_audit.UNEXPECTED_GROUP_ACCESS)
+        self.assertEqual(record.note, collab_audit.GROUP_NOT_ALLOWED)
+
+    def test_group_not_in_auth_domain(self):
+        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
+        # Add a group to the auth domain.
+        group = ManagedGroupFactory.create()
+        collab_audit = audit.CollaborativeAnalysisWorkspaceAccessAudit()
+        collab_audit._audit_workspace_and_group(workspace, group)
+        self.assertEqual(len(collab_audit.verified), 1)
+        self.assertEqual(len(collab_audit.needs_action), 0)
+        self.assertEqual(len(collab_audit.errors), 0)
+        record = collab_audit.verified[0]
+        self.assertIsInstance(record, audit.VerifiedNoAccess)
+        self.assertEqual(record.collaborative_analysis_workspace, workspace)
+        self.assertEqual(record.member, group)
+        self.assertEqual(record.note, collab_audit.GROUP_NOT_ALLOWED)
 
     def test_ignores_primed_admins_group(self):
         workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
@@ -1994,7 +2009,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertIsInstance(record, audit.RemoveAccess)
         self.assertEqual(record.collaborative_analysis_workspace, workspace)
         self.assertEqual(record.member, group)
-        self.assertEqual(record.note, collab_audit.UNEXPECTED_GROUP_ACCESS)
+        self.assertEqual(record.note, collab_audit.GROUP_NOT_ALLOWED)
 
     def test_error_for_primed_cc_writers_group(self):
         workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
@@ -2013,7 +2028,7 @@ class CollaborativeAnalysisWorkspaceAccessAudit(TestCase):
         self.assertIsInstance(record, audit.RemoveAccess)
         self.assertEqual(record.collaborative_analysis_workspace, workspace)
         self.assertEqual(record.member, group)
-        self.assertEqual(record.note, collab_audit.UNEXPECTED_GROUP_ACCESS)
+        self.assertEqual(record.note, collab_audit.GROUP_NOT_ALLOWED)
 
     def test_no_access_for_primed_cc_members_group(self):
         workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()

--- a/primed/collaborative_analysis/tests/test_views.py
+++ b/primed/collaborative_analysis/tests/test_views.py
@@ -1365,7 +1365,7 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(
             audit_result.note,
-            audit.CollaborativeAnalysisWorkspaceAccessAudit.NOT_IN_ANALYST_GROUP,
+            audit.CollaborativeAnalysisWorkspaceAccessAudit.NOT_IN_ANALYST_OR_CC_GROUP,
         )
 
     def test_get_verified_no_access_group(self):
@@ -1492,7 +1492,7 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(
             audit_result.note,
-            audit.CollaborativeAnalysisWorkspaceAccessAudit.NOT_IN_ANALYST_GROUP,
+            audit.CollaborativeAnalysisWorkspaceAccessAudit.NOT_IN_ANALYST_OR_CC_GROUP,
         )
 
     def test_get_remove_access_group(self):

--- a/primed/collaborative_analysis/tests/test_views.py
+++ b/primed/collaborative_analysis/tests/test_views.py
@@ -841,7 +841,7 @@ class WorkspaceAuditTest(TestCase):
         self.assertEqual(table.rows[0].get_cell_value("member"), group)
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.CollaborativeAnalysisWorkspaceAccessAudit.UNEXPECTED_GROUP_ACCESS,
+            audit.CollaborativeAnalysisWorkspaceAccessAudit.GROUP_NOT_ALLOWED,
         )
         self.assertIsNotNone(table.rows[0].get_cell_value("action"))
 
@@ -1126,7 +1126,7 @@ class WorkspaceAuditAllTest(TestCase):
         self.assertEqual(table.rows[0].get_cell_value("member"), group)
         self.assertEqual(
             table.rows[0].get_cell_value("note"),
-            audit.CollaborativeAnalysisWorkspaceAccessAudit.UNEXPECTED_GROUP_ACCESS,
+            audit.CollaborativeAnalysisWorkspaceAccessAudit.GROUP_NOT_ALLOWED,
         )
         self.assertIsNotNone(table.rows[0].get_cell_value("action"))
 
@@ -1303,36 +1303,6 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
             audit.CollaborativeAnalysisWorkspaceAccessAudit.IN_SOURCE_AUTH_DOMAINS,
         )
 
-    def test_get_verified_access_group(self):
-        """Get request with verified access for a group."""
-        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
-        group = ManagedGroupFactory.create(name="PRIMED_CC_WRITERS")
-        # Auth domain membership.
-        GroupGroupMembershipFactory.create(
-            parent_group=workspace.workspace.authorization_domains.get(),
-            child_group=group,
-        )
-        self.client.force_login(self.user)
-        response = self.client.get(
-            self.get_url(
-                workspace.workspace.billing_project.name,
-                workspace.workspace.name,
-                group.email,
-            )
-        )
-        self.assertIn("audit_result", response.context_data)
-        audit_result = response.context_data["audit_result"]
-        self.assertIsInstance(audit_result, audit.VerifiedAccess)
-        self.assertEqual(audit_result.collaborative_analysis_workspace, workspace)
-        self.assertEqual(
-            audit_result.member,
-            group,
-        )
-        self.assertEqual(
-            audit_result.note,
-            audit.CollaborativeAnalysisWorkspaceAccessAudit.DCC_ACCESS,
-        )
-
     def test_get_verified_no_access_account(self):
         """Get request with verified no access for an account."""
         workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
@@ -1392,7 +1362,7 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_result.member, group)
         self.assertEqual(
             audit_result.note,
-            audit.CollaborativeAnalysisWorkspaceAccessAudit.NON_DCC_GROUP,
+            audit.CollaborativeAnalysisWorkspaceAccessAudit.GROUP_NOT_ALLOWED,
         )
 
     def test_get_grant_access_account(self):
@@ -1428,36 +1398,6 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(
             audit_result.note,
             audit.CollaborativeAnalysisWorkspaceAccessAudit.IN_SOURCE_AUTH_DOMAINS,
-        )
-
-    def test_get_grant_access_group(self):
-        """Get request with verified access for a group."""
-        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
-        group = ManagedGroupFactory.create(name="PRIMED_CC_WRITERS")
-        # Auth domain membership.
-        # GroupGroupMembershipFactory.create(
-        #     parent_group=workspace.workspace.authorization_domains.get(),
-        #     child_group=group,
-        # )
-        self.client.force_login(self.user)
-        response = self.client.get(
-            self.get_url(
-                workspace.workspace.billing_project.name,
-                workspace.workspace.name,
-                group.email,
-            )
-        )
-        self.assertIn("audit_result", response.context_data)
-        audit_result = response.context_data["audit_result"]
-        self.assertIsInstance(audit_result, audit.GrantAccess)
-        self.assertEqual(audit_result.collaborative_analysis_workspace, workspace)
-        self.assertEqual(
-            audit_result.member,
-            group,
-        )
-        self.assertEqual(
-            audit_result.note,
-            audit.CollaborativeAnalysisWorkspaceAccessAudit.DCC_ACCESS,
         )
 
     def test_get_remove_access_account(self):
@@ -1522,7 +1462,7 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(
             audit_result.note,
-            audit.CollaborativeAnalysisWorkspaceAccessAudit.UNEXPECTED_GROUP_ACCESS,
+            audit.CollaborativeAnalysisWorkspaceAccessAudit.GROUP_NOT_ALLOWED,
         )
 
     def test_post_verified_access_account(self):
@@ -1547,30 +1487,6 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
                 workspace.workspace.billing_project.name,
                 workspace.workspace.name,
                 account.email,
-            ),
-            {},
-        )
-        self.assertRedirects(response, workspace.get_absolute_url())
-        membership.refresh_from_db()
-        self.assertEqual(membership.created, date_created)
-
-    def test_post_verified_access_group(self):
-        """Post request with verified access for a group."""
-        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create()
-        group = ManagedGroupFactory.create(name="PRIMED_CC_WRITERS")
-        # Auth domain membership.
-        date_created = timezone.now() - timedelta(weeks=5)
-        with freeze_time(date_created):
-            membership = GroupGroupMembershipFactory.create(
-                parent_group=workspace.workspace.authorization_domains.get(),
-                child_group=group,
-            )
-        self.client.force_login(self.user)
-        response = self.client.post(
-            self.get_url(
-                workspace.workspace.billing_project.name,
-                workspace.workspace.name,
-                group.email,
             ),
             {},
         )
@@ -1665,42 +1581,6 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
             account=account,
         )
         self.assertEqual(membership.role, GroupAccountMembership.RoleChoices.MEMBER)
-
-    def test_post_grant_access_group(self):
-        """Get request with verified access for a group."""
-        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create(workspace__name="TEST_COLLAB")
-        group = ManagedGroupFactory.create(name="PRIMED_CC_WRITERS")
-        # Auth domain membership.
-        # GroupGroupMembershipFactory.create(
-        #     parent_group=workspace.workspace.authorization_domains.get(),
-        #     child_group=group,
-        # )
-        # Add API response
-        # Note that the auth domain group is created automatically by the factory using the workspace name.
-        api_url = (
-            self.api_client.sam_entry_point + "/api/groups/v1/auth_TEST_COLLAB/member/PRIMED_CC_WRITERS@firecloud.org"
-        )
-        self.anvil_response_mock.add(
-            responses.PUT,
-            api_url,
-            status=204,
-        )
-        self.client.force_login(self.user)
-        response = self.client.post(
-            self.get_url(
-                workspace.workspace.billing_project.name,
-                workspace.workspace.name,
-                group.email,
-            ),
-            {},
-        )
-        self.assertRedirects(response, workspace.get_absolute_url())
-        # A membership was created.
-        membership = GroupGroupMembership.objects.get(
-            parent_group=workspace.workspace.authorization_domains.get(),
-            child_group=group,
-        )
-        self.assertEqual(membership.role, GroupGroupMembership.RoleChoices.MEMBER)
 
     def test_post_remove_access_account(self):
         """Get request with verified access."""
@@ -1810,47 +1690,6 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
             account=account,
         )
         self.assertEqual(membership.role, GroupAccountMembership.RoleChoices.MEMBER)
-
-    def test_post_grant_access_group_htmx(self):
-        """Get request with verified access for a group."""
-        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create(workspace__name="TEST_COLLAB")
-        group = ManagedGroupFactory.create(name="PRIMED_CC_WRITERS")
-        # Auth domain membership.
-        # GroupGroupMembershipFactory.create(
-        #     parent_group=workspace.workspace.authorization_domains.get(),
-        #     child_group=group,
-        # )
-        # Add API response
-        # Note that the auth domain group is created automatically by the factory using the workspace name.
-        api_url = (
-            self.api_client.sam_entry_point + "/api/groups/v1/auth_TEST_COLLAB/member/PRIMED_CC_WRITERS@firecloud.org"
-        )
-        self.anvil_response_mock.add(
-            responses.PUT,
-            api_url,
-            status=204,
-        )
-        self.client.force_login(self.user)
-        header = {"HTTP_HX-Request": "true"}
-        response = self.client.post(
-            self.get_url(
-                workspace.workspace.billing_project.name,
-                workspace.workspace.name,
-                group.email,
-            ),
-            {},
-            **header,
-        )
-        self.assertEqual(
-            response.content.decode(),
-            views.CollaborativeAnalysisAuditResolve.htmx_success,
-        )
-        # A membership was created.
-        membership = GroupGroupMembership.objects.get(
-            parent_group=workspace.workspace.authorization_domains.get(),
-            child_group=group,
-        )
-        self.assertEqual(membership.role, GroupGroupMembership.RoleChoices.MEMBER)
 
     def test_post_remove_access_account_htmx(self):
         """Get request with verified access."""
@@ -1962,47 +1801,6 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         # No new membership was created.
         self.assertEqual(GroupAccountMembership.objects.count(), 1)
-        # Audit result is the same.
-        self.assertIn("audit_result", response.context_data)
-        audit_result = response.context_data["audit_result"]
-        self.assertIsInstance(audit_result, audit.GrantAccess)
-        # A message was added.
-        messages = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertEqual(len(messages), 1)
-        self.assertIn("AnVIL API Error", str(messages[0]))
-
-    def test_anvil_error_grant_access_group(self):
-        """Get request with verified access for a group."""
-        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create(workspace__name="TEST_COLLAB")
-        group = ManagedGroupFactory.create(name="PRIMED_CC_WRITERS")
-        # Auth domain membership.
-        # GroupGroupMembershipFactory.create(
-        #     parent_group=workspace.workspace.authorization_domains.get(),
-        #     child_group=group,
-        # )
-        # Add API response
-        # Note that the auth domain group is created automatically by the factory using the workspace name.
-        api_url = (
-            self.api_client.sam_entry_point + "/api/groups/v1/auth_TEST_COLLAB/member/PRIMED_CC_WRITERS@firecloud.org"
-        )
-        self.anvil_response_mock.add(
-            responses.PUT,
-            api_url,
-            status=500,
-            json=ErrorResponseFactory().response,
-        )
-        self.client.force_login(self.user)
-        response = self.client.post(
-            self.get_url(
-                workspace.workspace.billing_project.name,
-                workspace.workspace.name,
-                group.email,
-            ),
-            {},
-        )
-        self.assertEqual(response.status_code, 200)
-        # No membership was created.
-        self.assertEqual(GroupGroupMembership.objects.count(), 0)
         # Audit result is the same.
         self.assertIn("audit_result", response.context_data)
         audit_result = response.context_data["audit_result"]
@@ -2135,47 +1933,6 @@ class CollaborativeAnalysisAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
         )
         # No new membership was created.
         self.assertEqual(GroupAccountMembership.objects.count(), 1)
-        # No message was added.
-        messages = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertEqual(len(messages), 0)
-
-    def test_anvil_error_grant_access_group_htmx(self):
-        """Get request with verified access for a group."""
-        workspace = factories.CollaborativeAnalysisWorkspaceFactory.create(workspace__name="TEST_COLLAB")
-        group = ManagedGroupFactory.create(name="PRIMED_CC_WRITERS")
-        # Auth domain membership.
-        # GroupGroupMembershipFactory.create(
-        #     parent_group=workspace.workspace.authorization_domains.get(),
-        #     child_group=group,
-        # )
-        # Add API response
-        # Note that the auth domain group is created automatically by the factory using the workspace name.
-        api_url = (
-            self.api_client.sam_entry_point + "/api/groups/v1/auth_TEST_COLLAB/member/PRIMED_CC_WRITERS@firecloud.org"
-        )
-        self.anvil_response_mock.add(
-            responses.PUT,
-            api_url,
-            status=500,
-            json=ErrorResponseFactory().response,
-        )
-        self.client.force_login(self.user)
-        header = {"HTTP_HX-Request": "true"}
-        response = self.client.post(
-            self.get_url(
-                workspace.workspace.billing_project.name,
-                workspace.workspace.name,
-                group.email,
-            ),
-            {},
-            **header,
-        )
-        self.assertEqual(
-            response.content.decode(),
-            views.CollaborativeAnalysisAuditResolve.htmx_error,
-        )
-        # No new membership was created.
-        self.assertEqual(GroupGroupMembership.objects.count(), 0)
         # No message was added.
         messages = [m.message for m in get_messages(response.wsgi_request)]
         self.assertEqual(len(messages), 0)


### PR DESCRIPTION
Update Collab analysis audits to:
- Do not add the PRIMED_CC_WRITERS group directly to the auth domain
- Instead, add individual members from the PRIMED_CC_WRITERS group

This makes the audit more streamlined (all groups except the admin group are errors), and allows for members in the CC group that do not have access to all source workspaces.