### PR TITLE
Update handling of outdated dbGaPDataAccessSnapshots

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -2,6 +2,7 @@
 Base settings to build other settings files upon.
 """
 
+from datetime import date
 from pathlib import Path
 
 import environ
@@ -396,7 +397,14 @@ DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
 # ------------------------------------------------------------------------------
 CONSTANCE_CONFIG = {
     "ANNOUNCEMENT_TEXT": ("", "Site-wide announcement message", str),
+    # Old fields for determining outdated status of a DAR snapshot.
     "DBGAP_SNAPSHOT_OLD_DAYS": (30, "Number of days before a dbGaP snapshot is considered old", int),
+    # New field for determining outdated status of a DAR snapshot.
+    "DBGAP_SNAPSHOT_OLD_DATE": (
+        None,
+        "Date before which a dbGaPDataAccessSnapshot is considered outdated.",
+        date,
+    ),
 }
 
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -397,8 +397,6 @@ DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
 # ------------------------------------------------------------------------------
 CONSTANCE_CONFIG = {
     "ANNOUNCEMENT_TEXT": ("", "Site-wide announcement message", str),
-    # Old fields for determining outdated status of a DAR snapshot.
-    "DBGAP_SNAPSHOT_OLD_DAYS": (30, "Number of days before a dbGaP snapshot is considered old", int),
     # New field for determining outdated status of a DAR snapshot.
     "DBGAP_SNAPSHOT_OLD_DATE": (
         None,

--- a/primed/dbgap/audit/access_audit.py
+++ b/primed/dbgap/audit/access_audit.py
@@ -1,13 +1,10 @@
 from dataclasses import dataclass
-from datetime import timedelta
 from typing import Optional
 
 import django_tables2 as tables
 from anvil_consortium_manager.exceptions import WorkspaceAccessAuthorizationDomainUnknownError
-from constance import config
 from django.db.models import QuerySet
 from django.urls import reverse
-from django.utils import timezone
 
 from primed.primed_anvil.audit import PRIMEDAudit, PRIMEDAuditResult
 from primed.primed_anvil.tables import BooleanIconColumn
@@ -248,9 +245,7 @@ class dbGaPAccessAudit(PRIMEDAudit):
             return  # Go to the next workspace.
 
         # Is snapshot more than 30 days old
-        snapshot_is_prior = app_snapshot.created.date() <= (
-            timezone.localdate() - timedelta(days=config.DBGAP_SNAPSHOT_OLD_DAYS)
-        )
+        snapshot_is_prior = app_snapshot.is_outdated()
 
         try:
             # There should only be one DAR from this snapshot associated with a given workspace.

--- a/primed/dbgap/models.py
+++ b/primed/dbgap/models.py
@@ -9,15 +9,18 @@ referencing (e.g., "dbgap_study_accession").
 
 import logging
 import re
+from datetime import datetime
 
 import jsonschema
 import requests
 from anvil_consortium_manager.models import BaseWorkspaceData, ManagedGroup
+from constance import config
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.urls import reverse
+from django.utils import timezone
 from django_extensions.db.models import TimeStampedModel
 from model_utils.models import StatusModel
 from simple_history.models import HistoricalRecords
@@ -370,6 +373,18 @@ class dbGaPDataAccessSnapshot(TimeStampedModel, models.Model):
         # Create the DARs in bulk - there are usually a lot of them.
         dars = dbGaPDataAccessRequest.objects.bulk_create(dars)
         return dars
+
+    def is_outdated(self):
+        """Determine whether a dbGaPDataAccessSnapshot is outdated."""
+        x = config.DBGAP_SNAPSHOT_OLD_DATE
+        if x is None:
+            return False
+        else:
+            cutoff = timezone.make_aware(
+                datetime(x.year, x.month, x.day),
+                timezone.get_default_timezone(),
+            )
+            return self.created < cutoff
 
 
 class dbGaPDataAccessRequest(TimeStampedModel, models.Model):

--- a/primed/dbgap/tests/test_audit.py
+++ b/primed/dbgap/tests/test_audit.py
@@ -1,5 +1,6 @@
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 
+import time_machine
 from anvil_consortium_manager.tests.factories import (
     AccountFactory,
     GroupAccountMembershipFactory,
@@ -7,7 +8,6 @@ from anvil_consortium_manager.tests.factories import (
     ManagedGroupFactory,
     WorkspaceAuthorizationDomainFactory,
 )
-from constance import config
 from constance.test import override_config
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -273,45 +273,14 @@ class dbGaPAccessAuditTest(TestCase):
         self.assertEqual(record.data_access_request, dar)
         self.assertTrue(dbgap_audit.ok())
 
-    def test_verified_access_dar_outdated_day_prior_to_cutoff(self):
-        """
-        Create a workspace and matching snapshot.
-        Snapshot day prior to cutoff
-        """
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(created=timezone.now() - timedelta(weeks=5))
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(days=config.DBGAP_SNAPSHOT_OLD_DAYS - 1),
-        )
-        # Add the anvil group to the auth group for the workspace.
-        GroupGroupMembershipFactory(
-            parent_group=dbgap_workspace.workspace.authorization_domains.get(),
-            child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
-        )
-
-        dbgap_audit = access_audit.dbGaPAccessAudit()
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 1)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.verified[0]
-        self.assertIsInstance(record, access_audit.VerifiedAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application)
-        self.assertEqual(record.data_access_request, dar)
-        self.assertTrue(dbgap_audit.ok())
-
-    @override_config(DBGAP_SNAPSHOT_OLD_DAYS=2)
-    def test_verified_access_dar_outdated_custom_day_prior_to_cutoff(self):
-        """
-        Create a workspace and matching snapshot.
-        Snapshot day prior to cutoff
-        """
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(created=timezone.now() - timedelta(weeks=5))
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(days=1),
-        )
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2025, 1, 1))
+    def test_verified_access_not_outdated(self):
+        """Create a workspace and matching snapshot that is not outdated."""
+        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
+        with time_machine.travel(datetime(2026, 1, 1, tzinfo=timezone.get_default_timezone())):
+            dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
+                dbgap_workspace=dbgap_workspace,
+            )
         # Add the anvil group to the auth group for the workspace.
         GroupGroupMembershipFactory(
             parent_group=dbgap_workspace.workspace.authorization_domains.get(),
@@ -428,16 +397,14 @@ class dbGaPAccessAuditTest(TestCase):
         self.assertEqual(record.note, access_audit.dbGaPAccessAudit.NO_DAR)
         self.assertTrue(dbgap_audit.ok())
 
-    def test_verified_no_access_dar_outdated_day_after_cutoff(self):
-        """
-        Create a workspace and matching snapshot.
-        Snapshot day prior to cutoff
-        """
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(created=timezone.now() - timedelta(weeks=5))
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(days=config.DBGAP_SNAPSHOT_OLD_DAYS + 1),
-        )
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2026, 1, 1))
+    def test_verified_no_access_outdated(self):
+        """Create a workspace and matching snapshot that is outdated."""
+        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
+        with time_machine.travel(datetime(2025, 1, 1, tzinfo=timezone.get_default_timezone())):
+            dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
+                dbgap_workspace=dbgap_workspace,
+            )
         # Do not add the anvil group to the auth group for the workspace.
         # GroupGroupMembershipFactory(
         #     parent_group=dbgap_workspace.workspace.authorization_domains.get(),
@@ -454,37 +421,6 @@ class dbGaPAccessAuditTest(TestCase):
         self.assertEqual(record.workspace, dbgap_workspace)
         self.assertEqual(record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application)
         self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(record.note, access_audit.dbGaPAccessAudit.APP_SNAPSHOT_OLD)
-        self.assertTrue(dbgap_audit.ok())
-
-    @override_config(DBGAP_SNAPSHOT_OLD_DAYS=2)
-    def test_verified_no_access_dar_outdated_custom_day_after_cutoff(self):
-        """
-        Create a workspace and matching snapshot.
-        Snapshot day prior to cutoff
-        """
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(created=timezone.now() - timedelta(weeks=5))
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(days=3),
-        )
-        # Do not add the anvil group to the auth group for the workspace.
-        # GroupGroupMembershipFactory(
-        #     parent_group=dbgap_workspace.workspace.authorization_domains.get(),
-        #     child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
-        # )
-
-        dbgap_audit = access_audit.dbGaPAccessAudit()
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 1)
-        self.assertEqual(len(dbgap_audit.needs_action), 0)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.verified[0]
-        self.assertIsInstance(record, access_audit.VerifiedNoAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application)
-        self.assertEqual(record.data_access_request, dar)
-        self.assertEqual(record.note, access_audit.dbGaPAccessAudit.APP_SNAPSHOT_OLD)
         self.assertTrue(dbgap_audit.ok())
 
     def test_verified_no_access_inactive(self):
@@ -684,116 +620,14 @@ class dbGaPAccessAuditTest(TestCase):
         self.assertEqual(record.note, access_audit.dbGaPAccessAudit.PREVIOUS_APPROVAL)
         self.assertFalse(dbgap_audit.ok())
 
-    def test_remove_access_dar_outdated_day_of_cutoff(self):
-        """
-        Create a workspace and matching snapshot.
-        Snapshot day of cutoff
-        """
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(created=timezone.now() - timedelta(weeks=5))
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-            - timedelta(days=config.DBGAP_SNAPSHOT_OLD_DAYS),
-        )
-        # Add the anvil group to the auth group for the workspace.
-        GroupGroupMembershipFactory(
-            parent_group=dbgap_workspace.workspace.authorization_domains.get(),
-            child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
-        )
-
-        dbgap_audit = access_audit.dbGaPAccessAudit()
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 1)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.needs_action[0]
-        self.assertIsInstance(record, access_audit.RemoveAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application)
-
-        self.assertEqual(record.note, access_audit.dbGaPAccessAudit.APP_SNAPSHOT_OLD)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application)
-        self.assertEqual(record.data_access_request, dar)
-        self.assertFalse(dbgap_audit.ok())
-
-    def test_remove_access_dar_outdated_day_after_cutoff(self):
-        """
-        Create a workspace and matching snapshot.
-        Snapshot day of cutoff
-        """
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(created=timezone.now() - timedelta(weeks=5))
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(days=config.DBGAP_SNAPSHOT_OLD_DAYS + 1),
-        )
-        # Add the anvil group to the auth group for the workspace.
-        GroupGroupMembershipFactory(
-            parent_group=dbgap_workspace.workspace.authorization_domains.get(),
-            child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
-        )
-
-        dbgap_audit = access_audit.dbGaPAccessAudit()
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 1)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.needs_action[0]
-        self.assertIsInstance(record, access_audit.RemoveAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application)
-
-        self.assertEqual(record.note, access_audit.dbGaPAccessAudit.APP_SNAPSHOT_OLD)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application)
-        self.assertEqual(record.data_access_request, dar)
-        self.assertFalse(dbgap_audit.ok())
-
-    @override_config(DBGAP_SNAPSHOT_OLD_DAYS=2)
-    def test_remove_access_dar_outdated_custom_day_of_cutoff(self):
-        """
-        Create a workspace and matching snapshot.
-        Snapshot day of cutoff
-        """
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(created=timezone.now() - timedelta(weeks=5))
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
-            - timedelta(days=2),
-        )
-        # Add the anvil group to the auth group for the workspace.
-        GroupGroupMembershipFactory(
-            parent_group=dbgap_workspace.workspace.authorization_domains.get(),
-            child_group=dar.dbgap_data_access_snapshot.dbgap_application.anvil_access_group,
-        )
-
-        dbgap_audit = access_audit.dbGaPAccessAudit()
-        dbgap_audit.run_audit()
-        self.assertEqual(len(dbgap_audit.verified), 0)
-        self.assertEqual(len(dbgap_audit.needs_action), 1)
-        self.assertEqual(len(dbgap_audit.errors), 0)
-        record = dbgap_audit.needs_action[0]
-        self.assertIsInstance(record, access_audit.RemoveAccess)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application)
-
-        self.assertEqual(record.note, access_audit.dbGaPAccessAudit.APP_SNAPSHOT_OLD)
-        self.assertEqual(record.workspace, dbgap_workspace)
-        self.assertEqual(record.dbgap_application, dar.dbgap_data_access_snapshot.dbgap_application)
-        self.assertEqual(record.data_access_request, dar)
-        self.assertFalse(dbgap_audit.ok())
-
-    @override_config(DBGAP_SNAPSHOT_OLD_DAYS=2)
-    def test_remove_access_dar_outdated_custom_day_after_cutoff(self):
-        """
-        Create a workspace and matching snapshot.
-        Snapshot day of cutoff
-        """
-        dbgap_workspace = factories.dbGaPWorkspaceFactory.create(created=timezone.now() - timedelta(weeks=5))
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=dbgap_workspace,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(days=3),
-        )
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2025, 1, 1))
+    def test_remove_access_dar_outdated(self):
+        """Create a workspace and matching snapshot that is outdated."""
+        dbgap_workspace = factories.dbGaPWorkspaceFactory.create()
+        with time_machine.travel(datetime(2024, 1, 1, tzinfo=timezone.get_default_timezone())):
+            dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
+                dbgap_workspace=dbgap_workspace,
+            )
         # Add the anvil group to the auth group for the workspace.
         GroupGroupMembershipFactory(
             parent_group=dbgap_workspace.workspace.authorization_domains.get(),

--- a/primed/dbgap/tests/test_models.py
+++ b/primed/dbgap/tests/test_models.py
@@ -1,13 +1,16 @@
 """Tests of models in the `dbgap` app."""
 
-from datetime import timedelta
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import jsonschema
 import responses
+import time_machine
 from anvil_consortium_manager.tests.factories import (
     ManagedGroupFactory,
     WorkspaceFactory,
 )
+from constance.test import override_config
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
 from django.db.utils import IntegrityError
@@ -21,6 +24,10 @@ from primed.users.tests.factories import UserFactory
 
 from .. import constants, models
 from . import factories
+
+# Naive datetimes not allowed
+# See docs: https://time-machine.readthedocs.io/en/latest/usage.html#time_machine.naive_mode
+time_machine.naive_mode = time_machine.NaiveMode.ERROR
 
 fake = Faker()
 
@@ -1211,6 +1218,76 @@ class dbGaPDataAccessSnapshotTest(TestCase):
             second_snapshot.create_dars_from_json()
         self.assertIn("project_id mismatch. previous_dar: 1234", str(e.exception))
         self.assertEqual(models.dbGaPDataAccessRequest.objects.count(), 1)
+
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=None)
+    def test_is_outdated_old_date_not_set(self):
+        snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertFalse(snapshot.is_outdated())
+        snapshot = factories.dbGaPDataAccessSnapshotFactory.create(created=timezone.now() - timedelta(days=365))
+        self.assertFalse(snapshot.is_outdated())
+
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2026, 5, 30))
+    def test_is_outdated_created_before_old_date(self):
+        # One year before old date.
+        with time_machine.travel(datetime(2025, 5, 30, 12, 0, 0, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertTrue(snapshot.is_outdated())
+        # One day before old date.
+        with time_machine.travel(datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertTrue(snapshot.is_outdated())
+        # One second before old date.
+        with time_machine.travel(datetime(2025, 5, 30, 23, 59, 59, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertTrue(snapshot.is_outdated())
+
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2026, 5, 30))
+    def test_is_outdated_created_after_old_date(self):
+        # One year after old date.
+        with time_machine.travel(datetime(2027, 5, 30, 12, 0, 0, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertFalse(snapshot.is_outdated())
+        # One day after old date.
+        with time_machine.travel(datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertFalse(snapshot.is_outdated())
+        # One second after old date.
+        with time_machine.travel(datetime(2026, 5, 31, 0, 0, 1, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertFalse(snapshot.is_outdated())
+
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2026, 5, 30))
+    def test_is_outdated_created_on_old_date(self):
+        # Middle of the date
+        with time_machine.travel(datetime(2026, 5, 30, 12, 0, 0, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertFalse(snapshot.is_outdated())
+        # Zeroth second of the day
+        with time_machine.travel(datetime(2026, 5, 30, 0, 0, 0, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertFalse(snapshot.is_outdated())
+        # First second of the day
+        with time_machine.travel(datetime(2026, 5, 30, 0, 0, 1, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertFalse(snapshot.is_outdated())
+        # Last second of the day
+        with time_machine.travel(datetime(2026, 5, 30, 23, 59, 59, tzinfo=timezone.get_default_timezone()), tick=False):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.assertFalse(snapshot.is_outdated())
+
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2026, 5, 15))
+    def test_is_outdated_timezones(self):
+        # Invalid snapshot in default timezone but not local timezone.
+        # This is an snapshot with a created time of 2026-05-14 23:59:59 in the default timezone.
+        with time_machine.travel(datetime(2026, 5, 14, 23, 59, 59, tzinfo=timezone.get_default_timezone())):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        with time_machine.travel(datetime(2026, 5, 15, 0, 0, 1, tzinfo=ZoneInfo("America/Denver")), tick=False):
+            self.assertTrue(snapshot.is_outdated())
+        # Valid snapshot in default timezone but not local timezone.
+        with time_machine.travel(datetime(2026, 5, 15, 0, 0, 1, tzinfo=timezone.get_default_timezone())):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        with time_machine.travel(datetime(2026, 5, 14, 23, 59, 59, tzinfo=ZoneInfo("America/Anchorage")), tick=False):
+            self.assertFalse(snapshot.is_outdated())
 
 
 class dbGaPDataAccessRequestTest(TestCase):

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -5460,13 +5460,12 @@ class dbGaPAccessAuditResolveTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertIsNotNone(audit_result.action)
 
-    def test_get_snapshot_needs_update(self):
-        """needs_action_table shows a record when audit finds that dar needs update."""
-        workspace = factories.dbGaPWorkspaceFactory.create(created=timezone.now() - timedelta(weeks=5))
-        dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(
-            dbgap_workspace=workspace,
-            dbgap_data_access_snapshot__created=timezone.now() - timedelta(weeks=5),
-        )
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2025, 1, 1))
+    def test_get_snapshot_outdated(self):
+        """needs_action_table shows a record when audit finds that dar is outdated."""
+        workspace = factories.dbGaPWorkspaceFactory.create()
+        with time_machine.travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.get_default_timezone())):
+            dar = factories.dbGaPDataAccessRequestForWorkspaceFactory.create(dbgap_workspace=workspace)
 
         GroupGroupMembershipFactory.create(
             parent_group=workspace.workspace.authorization_domains.get(),

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -1,9 +1,10 @@
 """Tests for views related to the `dbgap` app."""
 
 import json
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 
 import responses
+import time_machine
 from anvil_consortium_manager import views as acm_views
 from anvil_consortium_manager.models import (
     AnVILProjectManagerAccess,
@@ -23,6 +24,7 @@ from anvil_consortium_manager.tests.factories import (
     WorkspaceAuthorizationDomainFactory,
 )
 from anvil_consortium_manager.tests.utils import AnVILAPIMockTestMixin
+from constance.test import override_config
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -3869,13 +3871,13 @@ class dbGaPDataAccessSnapshotDetailTest(TestCase):
         table = response.context_data["summary_table"]
         self.assertEqual(len(table.rows), 0)
 
-    def test_no_alert_for_most_recent_snapshot(self):
+    def test_no_most_recent_alert_most_recent(self):
         """No alert is shown when this is the most recent snapshot for an application."""
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(self.application.dbgap_project_id, self.snapshot.pk))
         self.assertNotContains(response, "not the most recent snapshot", status_code=200)
 
-    def test_alert_when_not_most_recent_snapshot(self):
+    def test_no_most_recent_alert_not_most_recent(self):
         """An alert is shown when this is not the most recent snapshot for an application."""
         old_snapshot = factories.dbGaPDataAccessSnapshotFactory.create(
             dbgap_application=self.application,
@@ -3885,6 +3887,41 @@ class dbGaPDataAccessSnapshotDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(self.application.dbgap_project_id, old_snapshot.pk))
         self.assertContains(response, "not the most recent snapshot", status_code=200)
+
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2024, 5, 1))
+    def test_outdated_alert_not_outdated(self):
+        """No alert is shown when this snapshot is not outdated."""
+        with time_machine.travel(datetime(2025, 5, 1, tzinfo=timezone.get_current_timezone())):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(snapshot.dbgap_application.dbgap_project_id, snapshot.pk))
+        self.assertNotContains(response, "outdated", status_code=200)
+
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2024, 5, 1))
+    def test_outdated_alert_outdated(self):
+        """An alert is shown when this snapshot is outdated."""
+        with time_machine.travel(datetime(2023, 5, 1, tzinfo=timezone.get_current_timezone())):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create(
+                dbgap_application=self.application,
+                created=timezone.now() - timedelta(weeks=5),
+                is_most_recent=False,
+            )
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(snapshot.dbgap_application.dbgap_project_id, snapshot.pk))
+        self.assertContains(response, "outdated", status_code=200)
+
+    @override_config(DBGAP_SNAPSHOT_OLD_DATE=None)
+    def test_outdated_alert_no_outdated_date(self):
+        """No alert is shown when DBGAP_SNAPSHOT_OLD_DATE is not set."""
+        with time_machine.travel(datetime(2023, 5, 1, tzinfo=timezone.get_current_timezone())):
+            snapshot = factories.dbGaPDataAccessSnapshotFactory.create(
+                dbgap_application=self.application,
+                created=timezone.now() - timedelta(weeks=5),
+                is_most_recent=False,
+            )
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(snapshot.dbgap_application.dbgap_project_id, snapshot.pk))
+        self.assertNotContains(response, "outdated", status_code=200)
 
 
 class dbGaPDataAccessRequestListTest(TestCase):

--- a/primed/templates/dbgap/dbgapdataaccesssnapshot_detail.html
+++ b/primed/templates/dbgap/dbgapdataaccesssnapshot_detail.html
@@ -9,6 +9,11 @@
       This is not the most recent snapshot for this dbGaP application!
     </div>
   {% endif %}
+  {% if object.is_outdated %}
+    <div class="alert alert-danger" role="alert">
+      This snapshot is outdated.
+    </div>
+  {% endif %}
 {% endblock pills %}
 
 {% block panel %}

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -18,6 +18,8 @@ pytest-django  # https://github.com/pytest-dev/pytest-django
 django-test-migrations
 # Freeze time in tests.
 freezegun  # https://github.com/spulec/freezegun
+# Replacement for freezegun - better timezone support
+time-machine
 # Coverage of django templates
 django-coverage-plugin  # https://github.com/nedbat/django_coverage_plugin
 # Test coverage.

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -96,6 +96,8 @@ sqlparse==0.5.4
     #   django
 termcolor==2.4.0
     # via pytest-sugar
+time-machine==3.2.0
+    # via -r requirements/test-requirements.in
 typing-extensions==4.15.0
     # via django-test-migrations
 urllib3==2.6.3


### PR DESCRIPTION
Instead of requiring a snapshot be updated every X number of days, set a date in the app before which any snapshot is considered outdated. This is because we need to periodically request DAR info from investigators instead of being able to check at dbGaP.

I initially tried to code this as a "next deadline" and "days before" configuration parameters, but this doesn't work in the situation of having future deadlines; the code would need to know *all* of the deadlines that had been set (or possibly just the previous one, unclear). The most straightforward thing to do was to have the config be one date and consider anything before that date to be outdated. That date can be changed as necessary.

To implement the plan of e.g., giving investigators a deadline by which to send in DARs but allowing anything sent within 30 days before that date to be ok, we would just enter the deadline - 30 days as the config value.

Closes #1404
