### PR TITLE
Bugfix: Change default setting for DBGAP_SNAPSHOT_OLD_DATE

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -399,7 +399,7 @@ CONSTANCE_CONFIG = {
     "ANNOUNCEMENT_TEXT": ("", "Site-wide announcement message", str),
     # New field for determining outdated status of a DAR snapshot.
     "DBGAP_SNAPSHOT_OLD_DATE": (
-        None,
+        date(2026, 1, 1),
         "Date before which a dbGaPDataAccessSnapshot is considered outdated.",
         date,
     ),

--- a/primed/dbgap/tests/test_models.py
+++ b/primed/dbgap/tests/test_models.py
@@ -1219,13 +1219,6 @@ class dbGaPDataAccessSnapshotTest(TestCase):
         self.assertIn("project_id mismatch. previous_dar: 1234", str(e.exception))
         self.assertEqual(models.dbGaPDataAccessRequest.objects.count(), 1)
 
-    @override_config(DBGAP_SNAPSHOT_OLD_DATE=None)
-    def test_is_outdated_old_date_not_set(self):
-        snapshot = factories.dbGaPDataAccessSnapshotFactory.create()
-        self.assertFalse(snapshot.is_outdated())
-        snapshot = factories.dbGaPDataAccessSnapshotFactory.create(created=timezone.now() - timedelta(days=365))
-        self.assertFalse(snapshot.is_outdated())
-
     @override_config(DBGAP_SNAPSHOT_OLD_DATE=date(2026, 5, 30))
     def test_is_outdated_created_before_old_date(self):
         # One year before old date.

--- a/primed/dbgap/tests/test_views.py
+++ b/primed/dbgap/tests/test_views.py
@@ -3910,19 +3910,6 @@ class dbGaPDataAccessSnapshotDetailTest(TestCase):
         response = self.client.get(self.get_url(snapshot.dbgap_application.dbgap_project_id, snapshot.pk))
         self.assertContains(response, "outdated", status_code=200)
 
-    @override_config(DBGAP_SNAPSHOT_OLD_DATE=None)
-    def test_outdated_alert_no_outdated_date(self):
-        """No alert is shown when DBGAP_SNAPSHOT_OLD_DATE is not set."""
-        with time_machine.travel(datetime(2023, 5, 1, tzinfo=timezone.get_current_timezone())):
-            snapshot = factories.dbGaPDataAccessSnapshotFactory.create(
-                dbgap_application=self.application,
-                created=timezone.now() - timedelta(weeks=5),
-                is_most_recent=False,
-            )
-        self.client.force_login(self.user)
-        response = self.client.get(self.get_url(snapshot.dbgap_application.dbgap_project_id, snapshot.pk))
-        self.assertNotContains(response, "outdated", status_code=200)
-
 
 class dbGaPDataAccessRequestListTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Apparently "None" is not allowed.